### PR TITLE
Update link to the OWASP Proactive Controls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ threatmodel "Tower of London" {
 
 See [Data Flow Diagram](#data-flow-diagram) for more information on how to construct data flow diagrams that are converted to PNGs automatically.
 
-To see an example of how to reference pre-defined control libraries for the [OWASP Proactive Controls](https://github.com/OWASP/www-project-proactive-controls/tree/7622bebed900a6a5d7b7b9b01fb3fe2b0e695545/v3/en) and [AWS Security Checklist](https://d1.awsstatic.com/whitepapers/Security/AWS_Security_Checklist.pdf) see [examples/tm3.hcl](examples/tm3.hcl). We also have the [MITRE ATT&CK Controls](https://attack.mitre.org/mitigations/enterprise/) [here](examples/MITRE_ATTACK_controls.hcl).
+To see an example of how to reference pre-defined control libraries for the [OWASP Proactive Controls](https://owasp.org/www-project-proactive-controls/) and [AWS Security Checklist](https://d1.awsstatic.com/whitepapers/Security/AWS_Security_Checklist.pdf) see [examples/tm3.hcl](examples/tm3.hcl). We also have the [MITRE ATT&CK Controls](https://attack.mitre.org/mitigations/enterprise/) [here](examples/MITRE_ATTACK_controls.hcl).
 
 To see a full description of the spec, see [here](spec.hcl) or run:
 


### PR DESCRIPTION
I've replaced the link to the OWASP Proactive Controls GitHub repo with a link to the OWASP website.