### PR TITLE
Update dashboard-templates.go

### DIFF
--- a/pkg/spec/dashboard-templates.go
+++ b/pkg/spec/dashboard-templates.go
@@ -72,6 +72,7 @@ Diagram: {{ .DiagramLink }}
 > STRIDE: {{ $stride := .Stride }}{{ range $index, $elem := .Stride }}{{ if $index}}, {{end}}{{.}}{{end}}
 {{- end}}
 {{- if .InformationAssetRefs }}
+
 Impacted Information Assets:
 
 {{ range .InformationAssetRefs }}* {{.}}


### PR DESCRIPTION
This branch adds a newline between template elements so they don't render together in GitHub markdown:

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/5049068/168167857-bdedc201-91a3-481b-a45f-0bd9c14370cd.png) |![image](https://user-images.githubusercontent.com/5049068/168167927-9d67ab42-ed2d-4c6b-b537-febbca25ea95.png) |