### PR TITLE
feat: more flexible file extensions.

### DIFF
--- a/cmd/hcltm/dashboard.go
+++ b/cmd/hcltm/dashboard.go
@@ -30,6 +30,7 @@ type DashboardCommand struct {
 	*GlobalCmdOptions
 	specCfg                 *spec.ThreatmodelSpecConfig
 	flagOutDir              string
+	flagOutExt              string
 	flagOverwrite           bool
 	flagNoDfd               bool
 	flagDashboardTemplate   string
@@ -47,8 +48,8 @@ Usage: hcltm dashboard [options] -outdir=<directory> <files>
   by <files>) 
 
  -outdir=<directory>
-   Directory to output MD files. Will create directory if it doesn't exist.
-   Must be set
+   Directory to output rendered files. Will create directory if it doesn't
+   exist. Must be set
 
 Options:
 
@@ -56,6 +57,9 @@ Options:
    Optional config file
 
  -overwrite
+
+ -out-ext=<ext>
+   Extension to use for files produced by the text templates.
 
  -nodfd
 
@@ -76,12 +80,13 @@ func (c *DashboardCommand) Run(args []string) int {
 
 	flagSet := c.GetFlagset("dashboard")
 	flagSet.StringVar(&c.flagOutDir, "outdir", "", "Directory to output MD files. Will create directory if it doesn't exist. Must be set")
+	flagSet.StringVar(&c.flagOutExt, "out-ext", "md", "Extension to use in filenames produced by the text templates.")
 	flagSet.StringVar(&c.flagDashboardTemplate, "dashboard-template", "", "Template file to override the default dashboard index file")
 	flagSet.StringVar(&c.flagDashboardFilename, "dashboard-filename", "dashboard", "Instead of writing dashboard.md, write to <filename>.md")
 	flagSet.StringVar(&c.flagThreatmodelTemplate, "threatmodel-template", "", "Template file to override the default threatmodel.md file(s)")
 	flagSet.BoolVar(&c.flagOverwrite, "overwrite", false, "Overwrite existing files in the outdir. Defaults to false")
 	flagSet.BoolVar(&c.flagNoDfd, "nodfd", false, "Do not include generated DFD images. Defaults to false")
-	flagSet.BoolVar(&c.flagDashboardHTML, "dashboard-html", false, "Instead of writing .md files, write .html files instead")
+	flagSet.BoolVar(&c.flagDashboardHTML, "dashboard-html", false, "Render as HTML instead of text. Implies --out-ext=html.")
 	flagSet.Parse(args)
 
 	if c.flagConfig != "" {
@@ -110,7 +115,7 @@ func (c *DashboardCommand) Run(args []string) int {
 		return 1
 	}
 
-	outExt := "md"
+	outExt := c.flagOutExt
 	if c.flagDashboardHTML {
 		outExt = "html"
 	}

--- a/cmd/hcltm/dashboard_test.go
+++ b/cmd/hcltm/dashboard_test.go
@@ -210,6 +210,44 @@ func TestDashboardOverwrite(t *testing.T) {
 
 }
 
+func TestDashboardCustomExtension(t *testing.T) {
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Error creating tmp dir: %s", err)
+	}
+
+	defer os.RemoveAll(d)
+
+	cmd := testDashboardCommand(t)
+
+	var code int
+
+	out := capturer.CaptureStdout(func() {
+		code = cmd.Run([]string{
+			fmt.Sprintf("-outdir=%s/out", d),
+			"-out-ext=rst",
+			"./testdata/tm1.hcl",
+		})
+	})
+
+	if code != 0 {
+		t.Errorf("Code did not equal 0: %d", code)
+	}
+
+	if !strings.Contains(out, fmt.Sprintf("Created the '%s/out' directory", d)) {
+		t.Errorf("%s did not contain %s", out, fmt.Sprintf("Created the '%s/out' directory", d))
+	}
+
+	dbfile, err := ioutil.ReadFile(fmt.Sprintf("%s/out/dashboard.rst", d))
+	if err != nil {
+		t.Fatalf("Error opening dashboard file: %s", err)
+	}
+
+	if !strings.Contains(string(dbfile), "tm1-tm1one.rst") {
+		t.Errorf("Expected %s to contain %s", dbfile, "tm1-tm1one.rst")
+	}
+}
+
 func TestDashboardExistingDir(t *testing.T) {
 	d, err := ioutil.TempDir("", "")
 	if err != nil {


### PR DESCRIPTION
**Topline:** This should retain the existing default behavior of rendering to markdown while also allowing other target formats.

**Background:** My team has been using hcltm's template system to produce asciidoc instead of markdown. This is another markup format. It allows some slightly more sophisticated formatting than markdown. It shares the distinction with markdown of being automatically rendered by GitHub for ease of consumption. This patch will allow us to rip out the stop-gap post-processing we do renaming files from *.md to *.adoc and updating links to match.