### PR TITLE
refactor(cloud): collapse the cloud API into one deep CloudClient (1/4)

### DIFF
--- a/cmd/threatcl/cloud_api_helpers.go
+++ b/cmd/threatcl/cloud_api_helpers.go
@@ -23,10 +23,10 @@ import (
 )
 
 // fetchUserInfo retrieves user information from the API
-func fetchUserInfo(token string, httpClient HTTPClient, fsSvc FileSystemService) (*whoamiResponse, error) {
-	url := fmt.Sprintf("%s/api/v1/users/me", getAPIBaseURL(fsSvc))
+func (c *CloudClient) FetchUserInfo() (*whoamiResponse, error) {
+	url := fmt.Sprintf("%s/api/v1/users/me", c.baseURL)
 
-	resp, err := makeAuthenticatedRequest("GET", url, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", url, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -44,27 +44,23 @@ func fetchUserInfo(token string, httpClient HTTPClient, fsSvc FileSystemService)
 	return &whoamiResp, nil
 }
 
-// uploadFile uploads a threat model file to the API
-func uploadFile(token, orgId, modelIdOrSlug, filePath string, ignoreLinkedControls bool, httpClient HTTPClient, fsSvc FileSystemService) error {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/upload", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelIdOrSlug))
-
-	// Read the file
-	fileData, err := fsSvc.ReadFile(filePath)
-	if err != nil {
-		return fmt.Errorf("%s: %w", ErrFailedToReadFile, err)
-	}
+// Upload uploads a threat model spec (already-read file bytes) to the API. The
+// caller reads the file itself and passes the base filename, so the client
+// stays free of filesystem concerns.
+func (c *CloudClient) Upload(modelIdOrSlug, filename string, content []byte, ignoreLinkedControls bool) error {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/upload", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelIdOrSlug))
 
 	// Create multipart form
 	var requestBody bytes.Buffer
 	writer := multipart.NewWriter(&requestBody)
 
 	// Add file field
-	fileWriter, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	fileWriter, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return fmt.Errorf("failed to create form file: %w", err)
 	}
 
-	_, err = fileWriter.Write(fileData)
+	_, err = fileWriter.Write(content)
 	if err != nil {
 		return fmt.Errorf("failed to write file data: %w", err)
 	}
@@ -89,11 +85,11 @@ func uploadFile(token, orgId, modelIdOrSlug, filePath string, ignoreLinkedContro
 		return fmt.Errorf("%s: %w", ErrFailedToCreateReq, err)
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	// Send request
-	resp, err := httpClient.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return fmt.Errorf("%s: %w", ErrFailedToConnect, err)
 	}
@@ -115,8 +111,8 @@ func uploadFile(token, orgId, modelIdOrSlug, filePath string, ignoreLinkedContro
 
 // downloadFileContent downloads a threat model file from the API and returns
 // its bytes without touching the filesystem.
-func downloadFileContent(apiURL, token string, httpClient HTTPClient) ([]byte, error) {
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+func (c *CloudClient) DownloadContent(apiURL string) ([]byte, error) {
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +130,10 @@ func downloadFileContent(apiURL, token string, httpClient HTTPClient) ([]byte, e
 	return body, nil
 }
 
-// downloadFile downloads a threat model file from the API and writes it to disk
-func downloadFile(apiURL, token, downloadPath string, overwrite bool, httpClient HTTPClient, fsSvc FileSystemService) error {
+// downloadToFile downloads a threat model file from the API and writes it to
+// disk. The network fetch lives on the client (DownloadContent); the overwrite
+// check and write stay here so the client stays filesystem-free.
+func downloadToFile(client *CloudClient, apiURL, downloadPath string, overwrite bool, fsSvc FileSystemService) error {
 	// Check if file exists and overwrite flag is not set
 	if !overwrite {
 		if _, err := fsSvc.Stat(downloadPath); err == nil {
@@ -143,7 +141,7 @@ func downloadFile(apiURL, token, downloadPath string, overwrite bool, httpClient
 		}
 	}
 
-	body, err := downloadFileContent(apiURL, token, httpClient)
+	body, err := client.DownloadContent(apiURL)
 	if err != nil {
 		return err
 	}
@@ -156,10 +154,10 @@ func downloadFile(apiURL, token, downloadPath string, overwrite bool, httpClient
 }
 
 // fetchThreatModel retrieves a single threat model
-func fetchThreatModel(token, orgId, modelIdOrSlug string, httpClient HTTPClient, fsSvc FileSystemService) (*threatModel, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelIdOrSlug))
+func (c *CloudClient) FetchThreatModel(modelIdOrSlug string) (*threatModel, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelIdOrSlug))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -185,10 +183,10 @@ func fetchThreatModel(token, orgId, modelIdOrSlug string, httpClient HTTPClient,
 }
 
 // deleteThreatModel deletes a threat model
-func deleteThreatModel(token, orgId, modelIdOrSlug string, httpClient HTTPClient, fsSvc FileSystemService) error {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelIdOrSlug))
+func (c *CloudClient) DeleteThreatModel(modelIdOrSlug string) error {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelIdOrSlug))
 
-	resp, err := makeAuthenticatedRequest("DELETE", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("DELETE", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return err
 	}
@@ -202,8 +200,8 @@ func deleteThreatModel(token, orgId, modelIdOrSlug string, httpClient HTTPClient
 }
 
 // updateThreatmodelStatus updates the status of a threat model
-func updateThreatmodelStatus(token, orgId, modelIdOrSlug, status string, httpClient HTTPClient, fsSvc FileSystemService) error {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/status", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelIdOrSlug))
+func (c *CloudClient) UpdateThreatmodelStatus(modelIdOrSlug, status string) error {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/status", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelIdOrSlug))
 
 	// Create the request payload
 	payload := map[string]string{
@@ -220,10 +218,10 @@ func updateThreatmodelStatus(token, orgId, modelIdOrSlug, status string, httpCli
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return err
 	}
@@ -237,10 +235,10 @@ func updateThreatmodelStatus(token, orgId, modelIdOrSlug, status string, httpCli
 }
 
 // fetchThreatModels retrieves all threat models for an organization
-func fetchThreatModels(token, orgId string, httpClient HTTPClient, fsSvc FileSystemService) ([]threatModel, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models", getAPIBaseURL(fsSvc), url.PathEscape(orgId))
+func (c *CloudClient) FetchThreatModels() ([]threatModel, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models", c.baseURL, url.PathEscape(c.orgId))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -259,10 +257,10 @@ func fetchThreatModels(token, orgId string, httpClient HTTPClient, fsSvc FileSys
 }
 
 // fetchThreatModelVersions retrieves all versions of a threat model
-func fetchThreatModelVersions(token, orgId, modelId string, httpClient HTTPClient, fsSvc FileSystemService) (*threatModelVersionsResponse, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelId))
+func (c *CloudClient) FetchThreatModelVersions(modelId string) (*threatModelVersionsResponse, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelId))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -288,8 +286,8 @@ func fetchThreatModelVersions(token, orgId, modelId string, httpClient HTTPClien
 }
 
 // createThreatModel creates a new threat model in the cloud
-func createThreatModel(token, orgId, name, description string, httpClient HTTPClient, fsSvc FileSystemService) (*threatModel, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models", getAPIBaseURL(fsSvc), url.PathEscape(orgId))
+func (c *CloudClient) CreateThreatModel(name, description string) (*threatModel, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models", c.baseURL, url.PathEscape(c.orgId))
 
 	// Create the request payload
 	payload := map[string]string{
@@ -308,11 +306,11 @@ func createThreatModel(token, orgId, name, description string, httpClient HTTPCl
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Set("Content-Type", "application/json")
 
 	// Send request
-	resp, err := httpClient.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to API: %w", err)
 	}
@@ -403,7 +401,7 @@ func updateHCLBackendThreatmodel(filePath, slug string, fsSvc FileSystemService)
 // - organization is valid and user can access - return orgid
 // - threatmodel name exists - return slug
 // - local file matches the latest version of the threatmodel - return version string
-func validateThreatModel(token, filePath string, httpClient HTTPClient, fsSvc FileSystemService, specCfg *spec.ThreatmodelSpecConfig) (*spec.ThreatmodelWrapped, string, string, string, error) {
+func validateThreatModel(client *CloudClient, filePath string, specCfg *spec.ThreatmodelSpecConfig) (*spec.ThreatmodelWrapped, string, string, string, error) {
 	orgValid := ""
 	tmNameValid := ""
 	tmFileMatchesVersion := ""
@@ -487,7 +485,7 @@ func validateThreatModel(token, filePath string, httpClient HTTPClient, fsSvc Fi
 	// fmt.Printf("✓ Backend organization specified: %s\n", backend.BackendOrg)
 
 	// Step 4: Fetch user information
-	whoamiResp, err := fetchUserInfo(token, httpClient, fsSvc)
+	whoamiResp, err := client.FetchUserInfo()
 	if err != nil {
 		return wrapped, orgValid, tmNameValid, tmFileMatchesVersion, fmt.Errorf("error fetching user information: %s", err)
 	}
@@ -521,8 +519,11 @@ func validateThreatModel(token, filePath string, httpClient HTTPClient, fsSvc Fi
 	// 	foundOrg.Role)
 
 	if backend.BackendTMShort != "" {
-		// Try and match this threat model
-		threatModel, err := fetchThreatModel(token, foundOrg.Organization.ID, backend.BackendTMShort, httpClient, fsSvc)
+		// Try and match this threat model. The org is resolved from the
+		// file's backend block (not the client's construction org), so scope a
+		// copy of the client to it.
+		orgClient := client.WithOrg(foundOrg.Organization.ID)
+		threatModel, err := orgClient.FetchThreatModel(backend.BackendTMShort)
 		if err != nil && !strings.Contains(err.Error(), "threat model not found") {
 			return wrapped, orgValid, tmNameValid, tmFileMatchesVersion, fmt.Errorf("error fetching threat models: %s", err)
 		}
@@ -532,7 +533,7 @@ func validateThreatModel(token, filePath string, httpClient HTTPClient, fsSvc Fi
 			tmNameValid = threatModel.Slug
 			// fmt.Printf("✓ Threat model '%s' found\n", threatModel.Name)
 
-			threatModelVersions, err := fetchThreatModelVersions(token, foundOrg.Organization.ID, threatModel.ID, httpClient, fsSvc)
+			threatModelVersions, err := orgClient.FetchThreatModelVersions(threatModel.ID)
 			if err != nil {
 				return wrapped, orgValid, tmNameValid, tmFileMatchesVersion, fmt.Errorf("error fetching threat model versions: %s", err)
 			}
@@ -710,12 +711,12 @@ func extractInformationAssetRefs(wrapped *spec.ThreatmodelWrapped) []string {
 
 // validateControlRefs validates that control refs exist in the library
 // Returns a map of ref -> *controlLibraryItem (for found items), a slice of missing refs, and an error
-func validateControlRefs(token, orgId string, refs []string, httpClient HTTPClient, fsSvc FileSystemService) (map[string]*controlLibraryItem, []string, error) {
+func (c *CloudClient) ValidateControlRefs(refs []string) (map[string]*controlLibraryItem, []string, error) {
 	if len(refs) == 0 {
 		return nil, nil, nil
 	}
 
-	items, err := fetchControlLibraryItemsByRefs(token, orgId, refs, httpClient, fsSvc)
+	items, err := c.FetchControlLibraryItemsByRefs(refs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -740,7 +741,7 @@ func validateControlRefs(token, orgId string, refs []string, httpClient HTTPClie
 }
 
 // fetchControlLibraryItemByRef retrieves a control library item by its reference ID
-func fetchControlLibraryItemByRef(token, orgId, refId string, httpClient HTTPClient, fsSvc FileSystemService) (*controlLibraryItem, error) {
+func (c *CloudClient) FetchControlLibraryItemByRef(refId string) (*controlLibraryItem, error) {
 	query := `query controlLibraryItemByRef($orgId: ID!, $referenceId: String!) {
   controlLibraryItemByRef(orgId: $orgId, referenceId: $referenceId) {
     id
@@ -779,7 +780,7 @@ func fetchControlLibraryItemByRef(token, orgId, refId string, httpClient HTTPCli
 	reqBody := graphQLRequest{
 		Query: query,
 		Variables: map[string]interface{}{
-			"orgId":       orgId,
+			"orgId":       c.orgId,
 			"referenceId": refId,
 		},
 	}
@@ -789,8 +790,8 @@ func fetchControlLibraryItemByRef(token, orgId, refId string, httpClient HTTPCli
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/graphql", getAPIBaseURL(fsSvc))
-	resp, err := makeAuthenticatedRequest("POST", url, token, bytes.NewReader(jsonData), httpClient)
+	url := fmt.Sprintf("%s/api/v1/graphql", c.baseURL)
+	resp, err := makeAuthenticatedRequest("POST", url, c.token, bytes.NewReader(jsonData), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -824,7 +825,7 @@ func fetchControlLibraryItemByRef(token, orgId, refId string, httpClient HTTPCli
 }
 
 // fetchControlLibraryItemsByRefs retrieves multiple control library items by their reference IDs
-func fetchControlLibraryItemsByRefs(token, orgId string, refIds []string, httpClient HTTPClient, fsSvc FileSystemService) ([]*controlLibraryItem, error) {
+func (c *CloudClient) FetchControlLibraryItemsByRefs(refIds []string) ([]*controlLibraryItem, error) {
 	query := `query controlLibraryItemsByRefs($orgId: ID!, $referenceIds: [String!]!) {
   controlLibraryItemsByRefs(orgId: $orgId, referenceIds: $referenceIds) {
     id
@@ -863,7 +864,7 @@ func fetchControlLibraryItemsByRefs(token, orgId string, refIds []string, httpCl
 	reqBody := graphQLRequest{
 		Query: query,
 		Variables: map[string]any{
-			"orgId":        orgId,
+			"orgId":        c.orgId,
 			"referenceIds": refIds,
 		},
 	}
@@ -873,8 +874,8 @@ func fetchControlLibraryItemsByRefs(token, orgId string, refIds []string, httpCl
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/graphql", getAPIBaseURL(fsSvc))
-	resp, err := makeAuthenticatedRequest("POST", url, token, bytes.NewReader(jsonData), httpClient)
+	url := fmt.Sprintf("%s/api/v1/graphql", c.baseURL)
+	resp, err := makeAuthenticatedRequest("POST", url, c.token, bytes.NewReader(jsonData), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -904,7 +905,7 @@ func fetchControlLibraryItemsByRefs(token, orgId string, refIds []string, httpCl
 }
 
 // fetchThreatLibraryItemByRef retrieves a threat library item by its reference ID
-func fetchThreatLibraryItemByRef(token, orgId, refId string, httpClient HTTPClient, fsSvc FileSystemService) (*threatLibraryItem, error) {
+func (c *CloudClient) FetchThreatLibraryItemByRef(refId string) (*threatLibraryItem, error) {
 	query := `query threatLibraryItemByRef($orgId: ID!, $referenceId: String!) {
   threatLibraryItemByRef(orgId: $orgId, referenceId: $referenceId) {
     id
@@ -938,7 +939,7 @@ func fetchThreatLibraryItemByRef(token, orgId, refId string, httpClient HTTPClie
 	reqBody := graphQLRequest{
 		Query: query,
 		Variables: map[string]any{
-			"orgId":       orgId,
+			"orgId":       c.orgId,
 			"referenceId": refId,
 		},
 	}
@@ -948,8 +949,8 @@ func fetchThreatLibraryItemByRef(token, orgId, refId string, httpClient HTTPClie
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/graphql", getAPIBaseURL(fsSvc))
-	resp, err := makeAuthenticatedRequest("POST", url, token, bytes.NewReader(jsonData), httpClient)
+	url := fmt.Sprintf("%s/api/v1/graphql", c.baseURL)
+	resp, err := makeAuthenticatedRequest("POST", url, c.token, bytes.NewReader(jsonData), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -984,7 +985,7 @@ func fetchThreatLibraryItemByRef(token, orgId, refId string, httpClient HTTPClie
 
 // fetchThreatLibraryItemsByRefs retrieves multiple threat library items by their reference IDs
 // If includeRecommendedControls is true, the query will also fetch full details for recommended controls
-func fetchThreatLibraryItemsByRefs(token, orgId string, refIds []string, includeRecommendedControls bool, httpClient HTTPClient, fsSvc FileSystemService) ([]*threatLibraryItem, error) {
+func (c *CloudClient) FetchThreatLibraryItemsByRefs(refIds []string, includeRecommendedControls bool) ([]*threatLibraryItem, error) {
 	// Base query without recommended controls
 	query := `query threatLibraryItemsByRefs($orgId: ID!, $referenceIds: [String!]!) {
   threatLibraryItemsByRefs(orgId: $orgId, referenceIds: $referenceIds) {
@@ -1071,7 +1072,7 @@ func fetchThreatLibraryItemsByRefs(token, orgId string, refIds []string, include
 	reqBody := graphQLRequest{
 		Query: query,
 		Variables: map[string]any{
-			"orgId":        orgId,
+			"orgId":        c.orgId,
 			"referenceIds": refIds,
 		},
 	}
@@ -1081,8 +1082,8 @@ func fetchThreatLibraryItemsByRefs(token, orgId string, refIds []string, include
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/graphql", getAPIBaseURL(fsSvc))
-	resp, err := makeAuthenticatedRequest("POST", url, token, bytes.NewReader(jsonData), httpClient)
+	url := fmt.Sprintf("%s/api/v1/graphql", c.baseURL)
+	resp, err := makeAuthenticatedRequest("POST", url, c.token, bytes.NewReader(jsonData), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -1114,12 +1115,12 @@ func fetchThreatLibraryItemsByRefs(token, orgId string, refIds []string, include
 // validateThreatRefs validates that threat refs exist in the library
 // If includeRecommendedControls is true, the returned items will include full details for recommended controls
 // Returns a map of ref -> *threatLibraryItem (for found items), a slice of missing refs, and an error
-func validateThreatRefs(token, orgId string, refs []string, includeRecommendedControls bool, httpClient HTTPClient, fsSvc FileSystemService) (map[string]*threatLibraryItem, []string, error) {
+func (c *CloudClient) ValidateThreatRefs(refs []string, includeRecommendedControls bool) (map[string]*threatLibraryItem, []string, error) {
 	if len(refs) == 0 {
 		return nil, nil, nil
 	}
 
-	items, err := fetchThreatLibraryItemsByRefs(token, orgId, refs, includeRecommendedControls, httpClient, fsSvc)
+	items, err := c.FetchThreatLibraryItemsByRefs(refs, includeRecommendedControls)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1145,7 +1146,7 @@ func validateThreatRefs(token, orgId string, refs []string, includeRecommendedCo
 
 // fetchInformationAssetLibraryItemByRef retrieves an information-asset library
 // item by its reference ID.
-func fetchInformationAssetLibraryItemByRef(token, orgId, refId string, httpClient HTTPClient, fsSvc FileSystemService) (*informationAssetLibraryItem, error) {
+func (c *CloudClient) FetchInformationAssetLibraryItemByRef(refId string) (*informationAssetLibraryItem, error) {
 	query := `query informationAssetLibraryItemByRef($orgId: ID!, $referenceId: String!) {
   informationAssetLibraryItemByRef(orgId: $orgId, referenceId: $referenceId) {
     id
@@ -1181,7 +1182,7 @@ func fetchInformationAssetLibraryItemByRef(token, orgId, refId string, httpClien
 	reqBody := graphQLRequest{
 		Query: query,
 		Variables: map[string]any{
-			"orgId":       orgId,
+			"orgId":       c.orgId,
 			"referenceId": refId,
 		},
 	}
@@ -1191,8 +1192,8 @@ func fetchInformationAssetLibraryItemByRef(token, orgId, refId string, httpClien
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/graphql", getAPIBaseURL(fsSvc))
-	resp, err := makeAuthenticatedRequest("POST", url, token, bytes.NewReader(jsonData), httpClient)
+	url := fmt.Sprintf("%s/api/v1/graphql", c.baseURL)
+	resp, err := makeAuthenticatedRequest("POST", url, c.token, bytes.NewReader(jsonData), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -1227,7 +1228,7 @@ func fetchInformationAssetLibraryItemByRef(token, orgId, refId string, httpClien
 
 // fetchInformationAssetLibraryItemsByRefs retrieves multiple information-asset
 // library items by their reference IDs.
-func fetchInformationAssetLibraryItemsByRefs(token, orgId string, refIds []string, httpClient HTTPClient, fsSvc FileSystemService) ([]*informationAssetLibraryItem, error) {
+func (c *CloudClient) FetchInformationAssetLibraryItemsByRefs(refIds []string) ([]*informationAssetLibraryItem, error) {
 	query := `query informationAssetLibraryItemsByRefs($orgId: ID!, $referenceIds: [String!]!) {
   informationAssetLibraryItemsByRefs(orgId: $orgId, referenceIds: $referenceIds) {
     id
@@ -1263,7 +1264,7 @@ func fetchInformationAssetLibraryItemsByRefs(token, orgId string, refIds []strin
 	reqBody := graphQLRequest{
 		Query: query,
 		Variables: map[string]any{
-			"orgId":        orgId,
+			"orgId":        c.orgId,
 			"referenceIds": refIds,
 		},
 	}
@@ -1273,8 +1274,8 @@ func fetchInformationAssetLibraryItemsByRefs(token, orgId string, refIds []strin
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/graphql", getAPIBaseURL(fsSvc))
-	resp, err := makeAuthenticatedRequest("POST", url, token, bytes.NewReader(jsonData), httpClient)
+	url := fmt.Sprintf("%s/api/v1/graphql", c.baseURL)
+	resp, err := makeAuthenticatedRequest("POST", url, c.token, bytes.NewReader(jsonData), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -1306,12 +1307,12 @@ func fetchInformationAssetLibraryItemsByRefs(token, orgId string, refIds []strin
 // validateInformationAssetRefs validates that information-asset refs exist in
 // the library. Returns a map of ref -> *informationAssetLibraryItem (for found
 // items), a slice of missing refs, and an error.
-func validateInformationAssetRefs(token, orgId string, refs []string, httpClient HTTPClient, fsSvc FileSystemService) (map[string]*informationAssetLibraryItem, []string, error) {
+func (c *CloudClient) ValidateInformationAssetRefs(refs []string) (map[string]*informationAssetLibraryItem, []string, error) {
 	if len(refs) == 0 {
 		return nil, nil, nil
 	}
 
-	items, err := fetchInformationAssetLibraryItemsByRefs(token, orgId, refs, httpClient, fsSvc)
+	items, err := c.FetchInformationAssetLibraryItemsByRefs(refs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/threatcl/cloud_api_helpers_test.go
+++ b/cmd/threatcl/cloud_api_helpers_test.go
@@ -457,7 +457,7 @@ threatmodel "Test Model" {
 			}
 
 			// Call validateThreatModel
-			_, orgValid, tmNameValid, tmFileMatches, err := validateThreatModel("test-token", tmpFile.Name(), httpClient, fsSvc, cfg)
+			_, orgValid, tmNameValid, tmFileMatches, err := validateThreatModel(NewCloudClient("test-token", "", getAPIBaseURL(fsSvc), httpClient), tmpFile.Name(), cfg)
 
 			// Check return values
 			if orgValid != tt.expectedOrgValid {
@@ -563,7 +563,7 @@ func TestCreateThreatModel(t *testing.T) {
 				httpClient.transport.setResponse("POST", "/api/v1/org/org123/models", tt.statusCode, tt.response)
 			}
 
-			tm, err := createThreatModel("token", "org123", tt.modelName, tt.description, httpClient, fsSvc)
+			tm, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).CreateThreatModel(tt.modelName, tt.description)
 
 			if tt.expectError {
 				if err == nil {

--- a/cmd/threatcl/cloud_base.go
+++ b/cmd/threatcl/cloud_base.go
@@ -41,6 +41,23 @@ func (b *CloudCommandBase) initDependencies(timeout time.Duration) (HTTPClient, 
 	return httpClient, keyringSvc, fsSvc
 }
 
+// newCloudClient resolves the token and organization, then builds a CloudClient
+// bound to them, the configured API base URL and an HTTP transport with the
+// given timeout. It collapses the initDependencies -> getTokenAndOrgId ->
+// construct-client boilerplate that every cloud command used to repeat. The
+// resolved FileSystemService is returned so commands can still do their own
+// local file I/O (reading a spec to upload, writing a downloaded model, etc.).
+func (b *CloudCommandBase) newCloudClient(flagOrgId string, timeout time.Duration) (*CloudClient, FileSystemService, error) {
+	httpClient, keyringSvc, fsSvc := b.initDependencies(timeout)
+
+	token, orgId, err := b.getTokenAndOrgId(flagOrgId, keyringSvc, fsSvc)
+	if err != nil {
+		return nil, fsSvc, err
+	}
+
+	return NewCloudClient(token, orgId, getAPIBaseURL(fsSvc), httpClient), fsSvc, nil
+}
+
 // getTokenWithDeps retrieves the authentication token using provided dependencies
 // Deprecated: Use getTokenAndOrgId for new code that needs org-aware token retrieval
 func (b *CloudCommandBase) getTokenWithDeps(keyringSvc KeyringService, fsSvc FileSystemService) (string, error) {
@@ -120,8 +137,8 @@ func (b *CloudCommandBase) resolveOrgId(token string, flagOrgId string, httpClie
 		return envOrgId, nil
 	}
 
-	// Fetch user info to get first organization
-	whoamiResp, err := fetchUserInfo(token, httpClient, fsSvc)
+	// Fetch user info to get first organization (org-agnostic call)
+	whoamiResp, err := NewCloudClient(token, "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 	if err != nil {
 		return "", fmt.Errorf("error fetching user information: %w", err)
 	}

--- a/cmd/threatcl/cloud_client.go
+++ b/cmd/threatcl/cloud_client.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// CloudClient is the deep module for talking to the threatcl cloud API. It
+// captures the auth token, the active organization, the API base URL and the
+// HTTP transport once at construction so callers no longer thread
+// (token, orgId, httpClient, fsSvc) through every API call. Every cloud API
+// method hangs off this type; command code holds a *CloudClient and calls verbs
+// like client.FetchThreatModels().
+type CloudClient struct {
+	token   string
+	orgId   string
+	baseURL string
+	http    HTTPClient
+}
+
+// NewCloudClient builds a CloudClient bound to a token, organization and API
+// base URL over the given transport.
+func NewCloudClient(token, orgId, baseURL string, httpClient HTTPClient) *CloudClient {
+	return &CloudClient{
+		token:   token,
+		orgId:   orgId,
+		baseURL: baseURL,
+		http:    httpClient,
+	}
+}
+
+// OrgID returns the organization the client is currently scoped to.
+func (c *CloudClient) OrgID() string {
+	return c.orgId
+}
+
+// WithOrg returns a shallow copy of the client scoped to a different
+// organization, sharing the same token, base URL and transport. It is used when
+// an operation resolves the org dynamically (e.g. from a threat model's backend
+// block) rather than from the construction-time org.
+func (c *CloudClient) WithOrg(orgId string) *CloudClient {
+	clone := *c
+	clone.orgId = orgId
+	return &clone
+}
+
+// DownloadModelURL returns the API URL for downloading a threat model's current
+// spec file. Exposed so download commands can hand it to downloadToFile.
+func (c *CloudClient) DownloadModelURL(modelIdOrSlug string) string {
+	return fmt.Sprintf("%s/api/v1/org/%s/models/%s/download",
+		c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelIdOrSlug))
+}
+
+// DownloadModelVersionURL returns the API URL for downloading a specific version
+// of a threat model's spec file.
+func (c *CloudClient) DownloadModelVersionURL(modelIdOrSlug, version string) string {
+	return fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download",
+		c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelIdOrSlug), url.PathEscape(version))
+}

--- a/cmd/threatcl/cloud_client_test.go
+++ b/cmd/threatcl/cloud_client_test.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// recordingTransport is a self-contained HTTPClient that records every request
+// (method, URL, headers, body) and returns a single configured response. It lets
+// the CloudClient tests assert exactly what the client puts on the wire.
+type recordingTransport struct {
+	status int
+	body   string
+	err    error
+
+	reqs   []*http.Request
+	bodies []string
+}
+
+func (rt *recordingTransport) Do(req *http.Request) (*http.Response, error) {
+	var b []byte
+	if req.Body != nil {
+		b, _ = io.ReadAll(req.Body)
+	}
+	rt.reqs = append(rt.reqs, req)
+	rt.bodies = append(rt.bodies, string(b))
+	if rt.err != nil {
+		return nil, rt.err
+	}
+	resp := &http.Response{
+		StatusCode: rt.status,
+		Body:       io.NopCloser(strings.NewReader(rt.body)),
+		Header:     make(http.Header),
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	return resp, nil
+}
+
+func (rt *recordingTransport) Post(url, contentType string, body io.Reader) (*http.Response, error) {
+	req, _ := http.NewRequest("POST", url, body)
+	req.Header.Set("Content-Type", contentType)
+	return rt.Do(req)
+}
+
+func newTestClient(status int, body string) (*CloudClient, *recordingTransport) {
+	rt := &recordingTransport{status: status, body: body}
+	return NewCloudClient("tok-123", "org-abc", "https://api.test", rt), rt
+}
+
+func (rt *recordingTransport) last() *http.Request {
+	if len(rt.reqs) == 0 {
+		return nil
+	}
+	return rt.reqs[len(rt.reqs)-1]
+}
+
+// --- happy path: correct decode + exact request shape ---
+
+func TestCloudClientFetchThreatModels(t *testing.T) {
+	client, rt := newTestClient(http.StatusOK, `[{"id":"tm1","name":"One"},{"id":"tm2","name":"Two"}]`)
+
+	tms, err := client.FetchThreatModels()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tms) != 2 || tms[0].ID != "tm1" || tms[1].Name != "Two" {
+		t.Fatalf("unexpected decode: %+v", tms)
+	}
+
+	req := rt.last()
+	if req.Method != "GET" {
+		t.Errorf("method = %q, want GET", req.Method)
+	}
+	if got, want := req.URL.String(), "https://api.test/api/v1/org/org-abc/models"; got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok-123" {
+		t.Errorf("auth header = %q, want %q", got, "Bearer tok-123")
+	}
+}
+
+func TestCloudClientFetchThreatModelURL(t *testing.T) {
+	client, rt := newTestClient(http.StatusOK, `{"id":"tm1","slug":"my-model"}`)
+
+	tm, err := client.FetchThreatModel("my-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tm.Slug != "my-model" {
+		t.Errorf("slug = %q", tm.Slug)
+	}
+	if got, want := rt.last().URL.String(), "https://api.test/api/v1/org/org-abc/models/my-model"; got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}
+
+// --- PathEscape of org + path args ---
+
+func TestCloudClientPathEscaping(t *testing.T) {
+	rt := &recordingTransport{status: http.StatusOK, body: `{}`}
+	client := NewCloudClient("tok", "org with space", "https://api.test", rt)
+
+	_, _ = client.FetchThreatModel("a/b c")
+
+	got := rt.last().URL.EscapedPath()
+	if !strings.Contains(got, "org%20with%20space") {
+		t.Errorf("org not escaped in %q", got)
+	}
+	if !strings.Contains(got, "a%2Fb%20c") {
+		t.Errorf("model id not escaped in %q", got)
+	}
+}
+
+// --- error mapping: 401 / custom-404 / generic 404 / 500 ---
+
+func TestCloudClientUnauthorized(t *testing.T) {
+	client, _ := newTestClient(http.StatusUnauthorized, `{"error":"nope"}`)
+	_, err := client.FetchThreatModels()
+	if err == nil || !strings.Contains(err.Error(), "authentication failed") {
+		t.Fatalf("want auth-failed error, got %v", err)
+	}
+}
+
+func TestCloudClientCustomNotFound(t *testing.T) {
+	client, _ := newTestClient(http.StatusNotFound, `{"error":"nope"}`)
+	_, err := client.FetchThreatModel("ghost")
+	if err == nil || !strings.Contains(err.Error(), "threat model not found: ghost") {
+		t.Fatalf("want custom not-found, got %v", err)
+	}
+}
+
+func TestCloudClientServerError(t *testing.T) {
+	client, _ := newTestClient(http.StatusInternalServerError, `boom`)
+	_, err := client.FetchThreatModels()
+	if err == nil || !strings.Contains(err.Error(), "api returned status 500") {
+		t.Fatalf("want status-500 error, got %v", err)
+	}
+}
+
+func TestCloudClientTransportError(t *testing.T) {
+	rt := &recordingTransport{err: io.ErrUnexpectedEOF}
+	client := NewCloudClient("t", "o", "https://api.test", rt)
+	_, err := client.FetchThreatModels()
+	if err == nil {
+		t.Fatal("want transport error, got nil")
+	}
+}
+
+// --- WithOrg produces a re-scoped copy sharing token/baseURL ---
+
+func TestCloudClientWithOrg(t *testing.T) {
+	client, rt := newTestClient(http.StatusOK, `[]`)
+	other := client.WithOrg("org-xyz")
+
+	if other.OrgID() != "org-xyz" {
+		t.Errorf("OrgID = %q, want org-xyz", other.OrgID())
+	}
+	if client.OrgID() != "org-abc" {
+		t.Errorf("original org mutated: %q", client.OrgID())
+	}
+
+	_, _ = other.FetchThreatModels()
+	req := rt.last()
+	if got, want := req.URL.String(), "https://api.test/api/v1/org/org-xyz/models"; got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok-123" {
+		t.Errorf("token not shared with WithOrg copy: %q", got)
+	}
+}
+
+// --- CreateThreatModel accepts 200 AND 201, sends name+description ---
+
+func TestCloudClientCreateThreatModelAccepts201(t *testing.T) {
+	client, rt := newTestClient(http.StatusCreated, `{"id":"tm1","name":"New"}`)
+
+	tm, err := client.CreateThreatModel("New", "desc")
+	if err != nil {
+		t.Fatalf("201 should succeed, got %v", err)
+	}
+	if tm.Name != "New" {
+		t.Errorf("name = %q", tm.Name)
+	}
+	body := rt.bodies[len(rt.bodies)-1]
+	if !strings.Contains(body, `"name":"New"`) || !strings.Contains(body, `"description":"desc"`) {
+		t.Errorf("payload = %q", body)
+	}
+}
+
+func TestCloudClientCreateThreatModelAccepts200(t *testing.T) {
+	client, _ := newTestClient(http.StatusOK, `{"id":"tm1","name":"New"}`)
+	if _, err := client.CreateThreatModel("New", ""); err != nil {
+		t.Fatalf("200 should succeed, got %v", err)
+	}
+}
+
+// --- Upload sends multipart with the filename and content ---
+
+func TestCloudClientUpload(t *testing.T) {
+	client, rt := newTestClient(http.StatusOK, ``)
+
+	err := client.Upload("my-model", "model.hcl", []byte("spec-bytes"), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req := rt.last()
+	if got, want := req.URL.String(), "https://api.test/api/v1/org/org-abc/models/my-model/upload"; got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+	if ct := req.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
+		t.Errorf("content-type = %q, want multipart/form-data", ct)
+	}
+	body := rt.bodies[len(rt.bodies)-1]
+	if !strings.Contains(body, "model.hcl") || !strings.Contains(body, "spec-bytes") {
+		t.Errorf("multipart body missing filename/content: %q", body)
+	}
+	if !strings.Contains(body, "ignore-linked-controls") {
+		t.Errorf("multipart body missing ignore-linked-controls field: %q", body)
+	}
+}
+
+// --- EvaluatePolicies requires 201 exactly ---
+
+func TestCloudClientEvaluatePolicies201(t *testing.T) {
+	client, _ := newTestClient(http.StatusCreated, `{"id":"eval1","status":"completed"}`)
+	eval, err := client.EvaluatePolicies("model-1")
+	if err != nil {
+		t.Fatalf("201 should succeed, got %v", err)
+	}
+	if eval.ID != "eval1" {
+		t.Errorf("id = %q", eval.ID)
+	}
+}
+
+func TestCloudClientEvaluatePolicies200IsError(t *testing.T) {
+	client, _ := newTestClient(http.StatusOK, `{"id":"eval1"}`)
+	if _, err := client.EvaluatePolicies("model-1"); err == nil {
+		t.Fatal("200 (not 201) should be an error")
+	}
+}
+
+// --- DeletePolicy expects 204 ---
+
+func TestCloudClientDeletePolicy(t *testing.T) {
+	client, rt := newTestClient(http.StatusNoContent, ``)
+	if err := client.DeletePolicy("pol-1"); err != nil {
+		t.Fatalf("204 should succeed, got %v", err)
+	}
+	if rt.last().Method != "DELETE" {
+		t.Errorf("method = %q, want DELETE", rt.last().Method)
+	}
+}
+
+// --- Validate*Refs: empty short-circuits (no HTTP), missing detection ---
+
+func TestCloudClientValidateControlRefsEmpty(t *testing.T) {
+	rt := &recordingTransport{err: io.ErrUnexpectedEOF} // would fail if called
+	client := NewCloudClient("t", "o", "https://api.test", rt)
+
+	found, missing, err := client.ValidateControlRefs(nil)
+	if err != nil || found != nil || missing != nil {
+		t.Fatalf("empty refs should short-circuit, got (%v,%v,%v)", found, missing, err)
+	}
+	if len(rt.reqs) != 0 {
+		t.Errorf("expected no HTTP call, got %d", len(rt.reqs))
+	}
+}
+
+func TestCloudClientValidateControlRefsMissing(t *testing.T) {
+	client, _ := newTestClient(http.StatusOK,
+		`{"data":{"controlLibraryItemsByRefs":[{"referenceId":"C1","name":"Found"}]}}`)
+
+	found, missing, err := client.ValidateControlRefs([]string{"C1", "C2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := found["C1"]; !ok {
+		t.Errorf("C1 should be found: %+v", found)
+	}
+	if len(missing) != 1 || missing[0] != "C2" {
+		t.Errorf("missing = %v, want [C2]", missing)
+	}
+}
+
+func TestCloudClientValidateControlRefsGraphQLError(t *testing.T) {
+	client, _ := newTestClient(http.StatusOK, `{"errors":[{"message":"boom"}]}`)
+	_, _, err := client.ValidateControlRefs([]string{"C1"})
+	if err == nil || !strings.Contains(err.Error(), "GraphQL error") {
+		t.Fatalf("want GraphQL error, got %v", err)
+	}
+}
+
+// --- DownloadContent returns raw bytes on 200 ---
+
+func TestCloudClientDownloadContent(t *testing.T) {
+	client, _ := newTestClient(http.StatusOK, "raw-hcl-bytes")
+	body, err := client.DownloadContent("https://api.test/api/v1/org/org-abc/models/m/download")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != "raw-hcl-bytes" {
+		t.Errorf("body = %q", string(body))
+	}
+}
+
+// --- URL builders ---
+
+func TestCloudClientDownloadURLBuilders(t *testing.T) {
+	client := NewCloudClient("t", "org-abc", "https://api.test", &recordingTransport{})
+	if got, want := client.DownloadModelURL("m"), "https://api.test/api/v1/org/org-abc/models/m/download"; got != want {
+		t.Errorf("DownloadModelURL = %q, want %q", got, want)
+	}
+	if got, want := client.DownloadModelVersionURL("m", "1.2.0"), "https://api.test/api/v1/org/org-abc/models/m/versions/1.2.0/download"; got != want {
+		t.Errorf("DownloadModelVersionURL = %q, want %q", got, want)
+	}
+}

--- a/cmd/threatcl/cloud_create.go
+++ b/cmd/threatcl/cloud_create.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -125,16 +126,13 @@ func (c *CloudCreateCommand) Run(args []string) int {
 	if c.flagUpload != "" {
 		timeout = 30 * time.Second
 	}
-	httpClient, keyringSvc, fsSvc := c.initDependencies(timeout)
-
-	// Step 1: Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	client, fsSvc, err := c.newCloudClient(c.flagOrgId, timeout)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Create the threat model
-	threatModel, err := createThreatModel(token, orgId, c.flagName, c.flagDescription, httpClient, fsSvc)
+	// Create the threat model
+	threatModel, err := client.CreateThreatModel(c.flagName, c.flagDescription)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating threat model: %s\n", err)
 		return 1
@@ -147,12 +145,18 @@ func (c *CloudCreateCommand) Run(args []string) int {
 		fmt.Printf("  Description: %s\n", threatModel.Description)
 	}
 
-	// Step 4: Upload file if provided
+	// Upload file if provided. The caller reads the file so the client stays
+	// filesystem-free; the error text/flow matches the previous uploadFile path.
 	if c.flagUpload != "" {
 		fmt.Printf("\nUploading file %s...\n", c.flagUpload)
-		err := uploadFile(token, orgId, threatModel.Slug, c.flagUpload, false, httpClient, fsSvc)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error uploading file: %s\n", err)
+		content, uploadErr := fsSvc.ReadFile(c.flagUpload)
+		if uploadErr == nil {
+			uploadErr = client.Upload(threatModel.Slug, filepath.Base(c.flagUpload), content, false)
+		} else {
+			uploadErr = fmt.Errorf("%s: %w", ErrFailedToReadFile, uploadErr)
+		}
+		if uploadErr != nil {
+			fmt.Fprintf(os.Stderr, "Error uploading file: %s\n", uploadErr)
 			fmt.Fprintf(os.Stderr, "Note: The threat model was created successfully, but the upload failed.\n")
 			return 1
 		}

--- a/cmd/threatcl/cloud_create_test.go
+++ b/cmd/threatcl/cloud_create_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -264,7 +265,7 @@ func TestCloudCreateFetchUserInfo(t *testing.T) {
 
 			_ = testCloudCreateCommand(t, httpClient, nil, fsSvc)
 
-			resp, err := fetchUserInfo(tt.token, httpClient, fsSvc)
+			resp, err := NewCloudClient(tt.token, "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 
 			if tt.expectError {
 				if err == nil {
@@ -365,7 +366,7 @@ func TestCloudCreateCreateThreatModel(t *testing.T) {
 
 			_ = testCloudCreateCommand(t, httpClient, nil, fsSvc)
 
-			tm, err := createThreatModel("token", "org123", tt.modelName, tt.description, httpClient, fsSvc)
+			tm, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).CreateThreatModel(tt.modelName, tt.description)
 
 			if tt.expectError {
 				if err == nil {
@@ -767,7 +768,15 @@ func TestCloudCreateUploadFile(t *testing.T) {
 
 			_ = testCloudCreateCommand(t, httpClient, nil, fsSvc)
 
-			err := uploadFile("token", "org123", "test-model", tt.filePath, false, httpClient, fsSvc)
+			// Upload takes bytes; the caller reads the file (matching the
+			// command), so the file-read error path is exercised here.
+			content, err := fsSvc.ReadFile(tt.filePath)
+			if err == nil {
+				client := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient)
+				err = client.Upload("test-model", filepath.Base(tt.filePath), content, false)
+			} else {
+				err = fmt.Errorf("%s: %w", ErrFailedToReadFile, err)
+			}
 
 			if tt.expectError {
 				if err == nil {

--- a/cmd/threatcl/cloud_export.go
+++ b/cmd/threatcl/cloud_export.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,14 +113,12 @@ func (c *CloudExportCommand) Run(args []string) int {
 		}
 	}
 
-	httpClient, keyringSvc, fsSvc := c.initDependencies(30 * time.Second)
-
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	client, _, err := c.newCloudClient(c.flagOrgId, 30*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	if _, err := fetchThreatModel(token, orgId, c.flagModelId, httpClient, fsSvc); err != nil {
+	if _, err := client.FetchThreatModel(c.flagModelId); err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching threat model: %s\n", err)
 		return 1
 	}
@@ -134,12 +131,7 @@ func (c *CloudExportCommand) Run(args []string) int {
 		}
 	}
 
-	downloadURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download",
-		getAPIBaseURL(fsSvc),
-		url.PathEscape(orgId),
-		url.PathEscape(c.flagModelId),
-	)
-	hclBytes, err := downloadFileContent(downloadURL, token, httpClient)
+	hclBytes, err := client.DownloadContent(client.DownloadModelURL(c.flagModelId))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error downloading threat model file: %s\n", err)
 		return 1
@@ -174,7 +166,7 @@ func (c *CloudExportCommand) Run(args []string) int {
 	threatRefs := extractThreatRefs(wrapped)
 	threatItems := map[string]*threatLibraryItem{}
 	if len(threatRefs) > 0 {
-		fetched, err := fetchThreatLibraryItemsByRefs(token, orgId, threatRefs, c.flagIncludeRecommended, httpClient, fsSvc)
+		fetched, err := client.FetchThreatLibraryItemsByRefs(threatRefs, c.flagIncludeRecommended)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error resolving threat library refs: %s\n", err)
 			return 1
@@ -198,7 +190,7 @@ func (c *CloudExportCommand) Run(args []string) int {
 	controlRefs := extractControlRefs(wrapped)
 	controlItems := map[string]*controlLibraryItem{}
 	if len(controlRefs) > 0 {
-		fetched, err := fetchControlLibraryItemsByRefs(token, orgId, controlRefs, httpClient, fsSvc)
+		fetched, err := client.FetchControlLibraryItemsByRefs(controlRefs)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error resolving control library refs: %s\n", err)
 			return 1
@@ -222,7 +214,7 @@ func (c *CloudExportCommand) Run(args []string) int {
 	assetRefs := extractInformationAssetRefs(wrapped)
 	assetItems := map[string]*informationAssetLibraryItem{}
 	if len(assetRefs) > 0 {
-		fetched, err := fetchInformationAssetLibraryItemsByRefs(token, orgId, assetRefs, httpClient, fsSvc)
+		fetched, err := client.FetchInformationAssetLibraryItemsByRefs(assetRefs)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error resolving information asset library refs: %s\n", err)
 			return 1

--- a/cmd/threatcl/cloud_library_asset_ref.go
+++ b/cmd/threatcl/cloud_library_asset_ref.go
@@ -80,17 +80,14 @@ func (c *CloudLibraryAssetRefCommand) Run(args []string) int {
 	}
 	refId := remainingArgs[0]
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(30 * time.Second)
-
-	// Get token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 30*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch asset by reference ID
-	asset, err := fetchInformationAssetLibraryItemByRef(token, orgId, refId, httpClient, fsSvc)
+	asset, err := client.FetchInformationAssetLibraryItemByRef(refId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching information asset library item: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_library_control_ref.go
+++ b/cmd/threatcl/cloud_library_control_ref.go
@@ -80,17 +80,14 @@ func (c *CloudLibraryControlRefCommand) Run(args []string) int {
 	}
 	refId := remainingArgs[0]
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(30 * time.Second)
-
-	// Get token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 30*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch control by reference ID
-	control, err := fetchControlLibraryItemByRef(token, orgId, refId, httpClient, fsSvc)
+	control, err := client.FetchControlLibraryItemByRef(refId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching control library item: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_library_threat_ref.go
+++ b/cmd/threatcl/cloud_library_threat_ref.go
@@ -80,17 +80,14 @@ func (c *CloudLibraryThreatRefCommand) Run(args []string) int {
 	}
 	refId := remainingArgs[0]
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(30 * time.Second)
-
-	// Get token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 30*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch threat by reference ID
-	threat, err := fetchThreatLibraryItemByRef(token, orgId, refId, httpClient, fsSvc)
+	threat, err := client.FetchThreatLibraryItemByRef(refId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching threat library item: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_login.go
+++ b/cmd/threatcl/cloud_login.go
@@ -211,8 +211,8 @@ func (c *CloudLoginCommand) pollForToken(deviceResp *deviceCodeResponse, httpCli
 }
 
 func (c *CloudLoginCommand) fetchOrgName(token, orgId string, httpClient HTTPClient, fsSvc FileSystemService) string {
-	// Try to fetch user info to get org name
-	whoamiResp, err := fetchUserInfo(token, httpClient, fsSvc)
+	// Try to fetch user info to get org name (org-agnostic call)
+	whoamiResp, err := NewCloudClient(token, "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 	if err != nil {
 		return ""
 	}

--- a/cmd/threatcl/cloud_policies.go
+++ b/cmd/threatcl/cloud_policies.go
@@ -62,17 +62,14 @@ func (c *CloudPoliciesCommand) Run(args []string) int {
 	flagSet.BoolVar(&c.flagJSON, "json", false, "Output as JSON")
 	flagSet.Parse(args)
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch policies
-	policies, err := fetchPolicies(token, orgId, httpClient, fsSvc)
+	policies, err := client.FetchPolicies()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching policies: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policies_test.go
+++ b/cmd/threatcl/cloud_policies_test.go
@@ -307,7 +307,7 @@ func TestCloudPoliciesFetchPolicies(t *testing.T) {
 	}
 	httpClient.transport.setResponse("GET", "/api/v1/org/org123/policies", http.StatusOK, jsonResponse(policies))
 
-	result, err := fetchPolicies("token", "org123", httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchPolicies()
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_policy.go
+++ b/cmd/threatcl/cloud_policy.go
@@ -93,17 +93,14 @@ func (c *CloudPolicyCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch policy
-	p, err := fetchPolicy(token, orgId, c.flagPolicyId, httpClient, fsSvc)
+	p, err := client.FetchPolicy(c.flagPolicyId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching policy: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_api_helpers.go
+++ b/cmd/threatcl/cloud_policy_api_helpers.go
@@ -34,10 +34,10 @@ type policyUpdateRequest struct {
 }
 
 // fetchPolicies retrieves all policies for an organization
-func fetchPolicies(token, orgId string, httpClient HTTPClient, fsSvc FileSystemService) ([]policy, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies", getAPIBaseURL(fsSvc), url.PathEscape(orgId))
+func (c *CloudClient) FetchPolicies() ([]policy, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies", c.baseURL, url.PathEscape(c.orgId))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -56,10 +56,10 @@ func fetchPolicies(token, orgId string, httpClient HTTPClient, fsSvc FileSystemS
 }
 
 // fetchPolicy retrieves a single policy by ID
-func fetchPolicy(token, orgId, policyId string, httpClient HTTPClient, fsSvc FileSystemService) (*policy, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/%s", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(policyId))
+func (c *CloudClient) FetchPolicy(policyId string) (*policy, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/%s", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(policyId))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func fetchPolicy(token, orgId, policyId string, httpClient HTTPClient, fsSvc Fil
 }
 
 // createPolicy creates a new policy
-func createPolicy(token, orgId string, payload *policyCreateRequest, httpClient HTTPClient, fsSvc FileSystemService) (*policy, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies", getAPIBaseURL(fsSvc), url.PathEscape(orgId))
+func (c *CloudClient) CreatePolicy(payload *policyCreateRequest) (*policy, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies", c.baseURL, url.PathEscape(c.orgId))
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -98,10 +98,10 @@ func createPolicy(token, orgId string, payload *policyCreateRequest, httpClient 
 		return nil, fmt.Errorf("%s: %w", ErrFailedToCreateReq, err)
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ErrFailedToConnect, err)
 	}
@@ -125,8 +125,8 @@ func createPolicy(token, orgId string, payload *policyCreateRequest, httpClient 
 }
 
 // updatePolicy updates an existing policy
-func updatePolicy(token, orgId, policyId string, payload *policyUpdateRequest, httpClient HTTPClient, fsSvc FileSystemService) (*policy, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/%s", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(policyId))
+func (c *CloudClient) UpdatePolicy(policyId string, payload *policyUpdateRequest) (*policy, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/%s", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(policyId))
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -138,10 +138,10 @@ func updatePolicy(token, orgId, policyId string, payload *policyUpdateRequest, h
 		return nil, fmt.Errorf("%s: %w", ErrFailedToCreateReq, err)
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ErrFailedToConnect, err)
 	}
@@ -168,10 +168,10 @@ func updatePolicy(token, orgId, policyId string, payload *policyUpdateRequest, h
 }
 
 // deletePolicy deletes a policy
-func deletePolicy(token, orgId, policyId string, httpClient HTTPClient, fsSvc FileSystemService) error {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/%s", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(policyId))
+func (c *CloudClient) DeletePolicy(policyId string) error {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/%s", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(policyId))
 
-	resp, err := makeAuthenticatedRequest("DELETE", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("DELETE", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return err
 	}
@@ -202,16 +202,16 @@ type policyEvaluation struct {
 
 // policyEvaluationResult represents a single policy result within an evaluation
 type policyEvaluationResult struct {
-	ID             string                 `json:"id"`
-	EvaluationID   string                 `json:"evaluation_id"`
-	PolicyID       string                 `json:"policy_id"`
-	PolicyName     string                 `json:"policy_name"`
-	PolicySeverity string                 `json:"policy_severity"`
-	Passed         bool                   `json:"passed"`
-	Message        string                 `json:"message"`
+	ID             string         `json:"id"`
+	EvaluationID   string         `json:"evaluation_id"`
+	PolicyID       string         `json:"policy_id"`
+	PolicyName     string         `json:"policy_name"`
+	PolicySeverity string         `json:"policy_severity"`
+	Passed         bool           `json:"passed"`
+	Message        string         `json:"message"`
 	Details        map[string]any `json:"details,omitempty"`
-	DurationMs     int                    `json:"duration_ms"`
-	CreatedAt      string                 `json:"created_at"`
+	DurationMs     int            `json:"duration_ms"`
+	CreatedAt      string         `json:"created_at"`
 }
 
 // regoValidateRequest represents the request body for validating rego
@@ -226,8 +226,8 @@ type regoValidateResponse struct {
 }
 
 // validateRego validates rego source against the API
-func validateRego(token, orgId, regoSource string, httpClient HTTPClient, fsSvc FileSystemService) (*regoValidateResponse, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/validate", getAPIBaseURL(fsSvc), url.PathEscape(orgId))
+func (c *CloudClient) ValidateRego(regoSource string) (*regoValidateResponse, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/policies/validate", c.baseURL, url.PathEscape(c.orgId))
 
 	payload := regoValidateRequest{RegoSource: regoSource}
 	payloadBytes, err := json.Marshal(payload)
@@ -235,7 +235,7 @@ func validateRego(token, orgId, regoSource string, httpClient HTTPClient, fsSvc 
 		return nil, fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	resp, err := makeAuthenticatedRequest("POST", apiURL, token, bytes.NewReader(payloadBytes), httpClient)
+	resp, err := makeAuthenticatedRequest("POST", apiURL, c.token, bytes.NewReader(payloadBytes), c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -254,10 +254,10 @@ func validateRego(token, orgId, regoSource string, httpClient HTTPClient, fsSvc 
 }
 
 // evaluatePolicies triggers policy evaluation against a threat model
-func evaluatePolicies(token, orgId, modelId string, httpClient HTTPClient, fsSvc FileSystemService) (*policyEvaluation, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/evaluate-policies", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelId))
+func (c *CloudClient) EvaluatePolicies(modelId string) (*policyEvaluation, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/evaluate-policies", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelId))
 
-	resp, err := makeAuthenticatedRequest("POST", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("POST", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -283,10 +283,10 @@ func evaluatePolicies(token, orgId, modelId string, httpClient HTTPClient, fsSvc
 }
 
 // fetchPolicyEvaluations retrieves all evaluations for a threat model
-func fetchPolicyEvaluations(token, orgId, modelId string, httpClient HTTPClient, fsSvc FileSystemService) ([]policyEvaluation, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/policy-evaluations", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelId))
+func (c *CloudClient) FetchPolicyEvaluations(modelId string) ([]policyEvaluation, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/policy-evaluations", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelId))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}
@@ -305,10 +305,10 @@ func fetchPolicyEvaluations(token, orgId, modelId string, httpClient HTTPClient,
 }
 
 // fetchPolicyEvaluation retrieves a single evaluation by ID
-func fetchPolicyEvaluation(token, orgId, modelId, evalId string, httpClient HTTPClient, fsSvc FileSystemService) (*policyEvaluation, error) {
-	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/policy-evaluations/%s", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(modelId), url.PathEscape(evalId))
+func (c *CloudClient) FetchPolicyEvaluation(modelId, evalId string) (*policyEvaluation, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/policy-evaluations/%s", c.baseURL, url.PathEscape(c.orgId), url.PathEscape(modelId), url.PathEscape(evalId))
 
-	resp, err := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+	resp, err := makeAuthenticatedRequest("GET", apiURL, c.token, nil, c.http)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/threatcl/cloud_policy_create.go
+++ b/cmd/threatcl/cloud_policy_create.go
@@ -161,7 +161,8 @@ func (c *CloudPolicyCreateCommand) Run(args []string) int {
 	}
 
 	// Create policy
-	p, err := createPolicy(token, orgId, &payload, httpClient, fsSvc)
+	client := NewCloudClient(token, orgId, getAPIBaseURL(fsSvc), httpClient)
+	p, err := client.CreatePolicy(&payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating policy: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_delete.go
+++ b/cmd/threatcl/cloud_policy_delete.go
@@ -66,11 +66,8 @@ func (c *CloudPolicyDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
@@ -78,7 +75,7 @@ func (c *CloudPolicyDeleteCommand) Run(args []string) int {
 	// Confirmation prompt unless -force is set
 	if !c.flagForce {
 		// Fetch the policy first to show the name in the prompt
-		p, err := fetchPolicy(token, orgId, c.flagPolicyId, httpClient, fsSvc)
+		p, err := client.FetchPolicy(c.flagPolicyId)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error fetching policy: %s\n", err)
 			return 1
@@ -95,7 +92,7 @@ func (c *CloudPolicyDeleteCommand) Run(args []string) int {
 	}
 
 	// Delete policy
-	err = deletePolicy(token, orgId, c.flagPolicyId, httpClient, fsSvc)
+	err = client.DeletePolicy(c.flagPolicyId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error deleting policy: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_delete_test.go
+++ b/cmd/threatcl/cloud_policy_delete_test.go
@@ -150,7 +150,7 @@ func TestCloudPolicyDeletePolicy(t *testing.T) {
 
 	httpClient.transport.setResponse("DELETE", "/api/v1/org/org123/policies/pol-1", http.StatusNoContent, "")
 
-	err := deletePolicy("token", "org123", "pol-1", httpClient, fsSvc)
+	err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).DeletePolicy("pol-1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_policy_evaluate.go
+++ b/cmd/threatcl/cloud_policy_evaluate.go
@@ -83,17 +83,14 @@ func (c *CloudPolicyEvaluateCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Evaluate policies
-	eval, err := evaluatePolicies(token, orgId, c.flagModelId, httpClient, fsSvc)
+	eval, err := client.EvaluatePolicies(c.flagModelId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error evaluating policies: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_evaluate_test.go
+++ b/cmd/threatcl/cloud_policy_evaluate_test.go
@@ -387,7 +387,7 @@ func TestCloudPolicyEvaluatePolicies(t *testing.T) {
 	}
 	httpClient.transport.setResponse("POST", "/api/v1/org/org123/models/model-1/evaluate-policies", http.StatusCreated, jsonResponse(eval))
 
-	result, err := evaluatePolicies("token", "org123", "model-1", httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).EvaluatePolicies("model-1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_policy_evaluation.go
+++ b/cmd/threatcl/cloud_policy_evaluation.go
@@ -81,17 +81,14 @@ func (c *CloudPolicyEvaluationCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch evaluation
-	eval, err := fetchPolicyEvaluation(token, orgId, c.flagModelId, c.flagEvalId, httpClient, fsSvc)
+	eval, err := client.FetchPolicyEvaluation(c.flagModelId, c.flagEvalId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching evaluation: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_evaluation_test.go
+++ b/cmd/threatcl/cloud_policy_evaluation_test.go
@@ -239,7 +239,7 @@ func TestCloudPolicyFetchPolicyEvaluation(t *testing.T) {
 	}
 	httpClient.transport.setResponse("GET", "/api/v1/org/org123/models/model-1/policy-evaluations/eval-1", http.StatusOK, jsonResponse(eval))
 
-	result, err := fetchPolicyEvaluation("token", "org123", "model-1", "eval-1", httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchPolicyEvaluation("model-1", "eval-1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_policy_evaluations.go
+++ b/cmd/threatcl/cloud_policy_evaluations.go
@@ -75,17 +75,14 @@ func (c *CloudPolicyEvaluationsCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
 	// Fetch evaluations
-	evals, err := fetchPolicyEvaluations(token, orgId, c.flagModelId, httpClient, fsSvc)
+	evals, err := client.FetchPolicyEvaluations(c.flagModelId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching evaluations: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_evaluations_test.go
+++ b/cmd/threatcl/cloud_policy_evaluations_test.go
@@ -255,7 +255,7 @@ func TestCloudPolicyFetchPolicyEvaluations(t *testing.T) {
 	}
 	httpClient.transport.setResponse("GET", "/api/v1/org/org123/models/model-1/policy-evaluations", http.StatusOK, jsonResponse(evals))
 
-	result, err := fetchPolicyEvaluations("token", "org123", "model-1", httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchPolicyEvaluations("model-1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_policy_test.go
+++ b/cmd/threatcl/cloud_policy_test.go
@@ -298,7 +298,7 @@ func TestCloudPolicyFetchPolicy(t *testing.T) {
 	}
 	httpClient.transport.setResponse("GET", "/api/v1/org/org123/policies/pol-1", http.StatusOK, jsonResponse(p))
 
-	result, err := fetchPolicy("token", "org123", "pol-1", httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchPolicy("pol-1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -666,7 +666,7 @@ func TestCloudPolicyCreatePolicy(t *testing.T) {
 		Enabled:    &enabled,
 	}
 
-	result, err := createPolicy("token", "org123", payload, httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).CreatePolicy(payload)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -937,7 +937,7 @@ func TestCloudPolicyUpdatePolicy(t *testing.T) {
 		Severity: &severity,
 	}
 
-	result, err := updatePolicy("token", "org123", "pol-1", payload, httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).UpdatePolicy("pol-1", payload)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_policy_update.go
+++ b/cmd/threatcl/cloud_policy_update.go
@@ -189,7 +189,8 @@ func (c *CloudPolicyUpdateCommand) Run(args []string) int {
 	}
 
 	// Update policy
-	p, err := updatePolicy(token, orgId, c.flagPolicyId, &payload, httpClient, fsSvc)
+	client := NewCloudClient(token, orgId, getAPIBaseURL(fsSvc), httpClient)
+	p, err := client.UpdatePolicy(c.flagPolicyId, &payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error updating policy: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_validate.go
+++ b/cmd/threatcl/cloud_policy_validate.go
@@ -90,7 +90,8 @@ func (c *CloudPolicyValidateCommand) Run(args []string) int {
 	}
 
 	// Validate rego
-	result, err := validateRego(token, orgId, regoSource, httpClient, fsSvc)
+	client := NewCloudClient(token, orgId, getAPIBaseURL(fsSvc), httpClient)
+	result, err := client.ValidateRego(regoSource)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error validating policy: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_policy_validate_test.go
+++ b/cmd/threatcl/cloud_policy_validate_test.go
@@ -239,7 +239,7 @@ func TestCloudPolicyValidateRego(t *testing.T) {
 
 	httpClient.transport.setResponse("POST", "/api/v1/org/org123/policies/validate", http.StatusOK, `{"valid":true}`)
 
-	result, err := validateRego("token", "org123", "package threatcl.test\n", httpClient, fsSvc)
+	result, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).ValidateRego("package threatcl.test\n")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_push.go
+++ b/cmd/threatcl/cloud_push.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -94,11 +95,10 @@ func (c *CloudPushCommand) Run(args []string) int {
 		}
 	}
 
-	// Initialize dependencies - use longer timeout for upload
-	httpClient, keyringSvc, fsSvc := c.initDependencies(30 * time.Second)
-
-	// Step 1: Retrieve token (org will be determined from file content)
-	token, _, err := c.getTokenAndOrgId("", keyringSvc, fsSvc)
+	// Build the cloud client (30s timeout for upload). The org is determined
+	// from the file's backend block, not a flag, so start org-agnostic and
+	// re-scope with WithOrg once validateThreatModel resolves it.
+	client, fsSvc, err := c.newCloudClient("", 30*time.Second)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %s\n", err)
 		fmt.Fprintf(os.Stderr, "   %s\n", ErrPleaseLogin)
@@ -108,7 +108,7 @@ func (c *CloudPushCommand) Run(args []string) int {
 	// Step 2: Run validateThreatModel on the original file
 	// Note: validateThreatModel handles preprocessing internally for HCL parsing,
 	// while using the original content for hash calculation
-	wrapped, orgValid, tmNameValid, tmFileMatchesVersion, validateErr := validateThreatModel(token, filePath, httpClient, fsSvc, c.specCfg)
+	wrapped, orgValid, tmNameValid, tmFileMatchesVersion, validateErr := validateThreatModel(client, filePath, c.specCfg)
 
 	// Step 4: Handle validation results
 	if validateErr != nil {
@@ -129,6 +129,17 @@ func (c *CloudPushCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Scope the client to the file-resolved org, plus an upload helper that
+	// reads the file bytes (the client itself stays filesystem-free).
+	orgClient := client.WithOrg(orgValid)
+	uploadPush := func(slug string) error {
+		content, readErr := fsSvc.ReadFile(filePath)
+		if readErr != nil {
+			return fmt.Errorf("%s: %w", ErrFailedToReadFile, readErr)
+		}
+		return orgClient.Upload(slug, filepath.Base(filePath), content, c.flagIgnoreLinkedControls)
+	}
+
 	// Case: tmNameValid and tmFileMatchesVersion - version already matches
 	if tmNameValid != "" && tmFileMatchesVersion != "" {
 		fmt.Printf("✓ Cloud version matches local version (v%s), not pushing\n", tmFileMatchesVersion)
@@ -138,7 +149,7 @@ func (c *CloudPushCommand) Run(args []string) int {
 	// Case: tmNameValid but no version match - upload new version
 	if tmNameValid != "" && tmFileMatchesVersion == "" {
 		fmt.Printf("Uploading new version to threat model '%s'...\n", tmNameValid)
-		err = uploadFile(token, orgValid, tmNameValid, filePath, c.flagIgnoreLinkedControls, httpClient, fsSvc)
+		err = uploadPush(tmNameValid)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error uploading file: %s\n", err)
 			return 1
@@ -165,7 +176,7 @@ func (c *CloudPushCommand) Run(args []string) int {
 
 		// Create the threat model
 		fmt.Printf("Creating new threat model '%s'...\n", tmName)
-		newTM, err := createThreatModel(token, orgValid, tmName, tmDescription, httpClient, fsSvc)
+		newTM, err := orgClient.CreateThreatModel(tmName, tmDescription)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating threat model: %s\n", err)
 			return 1
@@ -219,7 +230,7 @@ func (c *CloudPushCommand) Run(args []string) int {
 
 		// Upload the updated file
 		fmt.Printf("Uploading threat model...\n")
-		err = uploadFile(token, orgValid, newTM.Slug, filePath, c.flagIgnoreLinkedControls, httpClient, fsSvc)
+		err = uploadPush(newTM.Slug)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error uploading file: %s\n", err)
 			fmt.Fprintf(os.Stderr, "Note: The threat model was created and local file updated, but the upload failed.\n")

--- a/cmd/threatcl/cloud_threatmodel.go
+++ b/cmd/threatcl/cloud_threatmodel.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -76,26 +75,23 @@ func (c *CloudThreatmodelCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Step 1: Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, fsSvc, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Fetch threat model
-	threatModel, err := fetchThreatModel(token, orgId, c.flagModelId, httpClient, fsSvc)
+	// Fetch threat model
+	threatModel, err := client.FetchThreatModel(c.flagModelId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching threat model: %s\n", err)
 		return 1
 	}
 
-	// Step 4: Download threat model file
+	// Download threat model file
 	if c.flagDownload != "" {
-		apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(c.flagModelId))
-		err = downloadFile(apiURL, token, c.flagDownload, c.flagOverwrite, httpClient, fsSvc)
+		apiURL := client.DownloadModelURL(c.flagModelId)
+		err = downloadToFile(client, apiURL, c.flagDownload, c.flagOverwrite, fsSvc)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error downloading threat model file: %s\n", err)
 			return 1

--- a/cmd/threatcl/cloud_threatmodel_delete.go
+++ b/cmd/threatcl/cloud_threatmodel_delete.go
@@ -61,17 +61,14 @@ func (c *CloudThreatmodelDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Step 1: Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Delete threat model
-	err = deleteThreatModel(token, orgId, c.flagModelId, httpClient, fsSvc)
+	// Delete threat model
+	err = client.DeleteThreatModel(c.flagModelId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error deleting threat model: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_threatmodel_test.go
+++ b/cmd/threatcl/cloud_threatmodel_test.go
@@ -263,7 +263,7 @@ func TestCloudThreatmodelFetchUserInfo(t *testing.T) {
 
 	_ = testCloudThreatmodelCommand(t, httpClient, nil, fsSvc)
 
-	resp, err := fetchUserInfo("token", httpClient, fsSvc)
+	resp, err := NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -298,7 +298,7 @@ func TestCloudThreatmodelFetchThreatModel(t *testing.T) {
 
 	_ = testCloudThreatmodelCommand(t, httpClient, nil, fsSvc)
 
-	model, err := fetchThreatModel("token", "org123", "tm1", httpClient, fsSvc)
+	model, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchThreatModel("tm1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -335,7 +335,7 @@ func TestCloudThreatmodelFetchThreatModelWithSlug(t *testing.T) {
 
 	_ = testCloudThreatmodelCommand(t, httpClient, nil, fsSvc)
 
-	model, err := fetchThreatModel("token", "org123", "threat-model-1", httpClient, fsSvc)
+	model, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchThreatModel("threat-model-1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -661,7 +661,7 @@ func TestCloudThreatmodelDownloadThreatModel(t *testing.T) {
 	_ = testCloudThreatmodelCommand(t, httpClient, nil, fsSvc)
 
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1")
-	err := downloadFile(url, "token", "test.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "test.hcl", false, fsSvc)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -688,7 +688,7 @@ func TestCloudThreatmodelDownloadThreatModelWithSlug(t *testing.T) {
 	_ = testCloudThreatmodelCommand(t, httpClient, nil, fsSvc)
 
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download", getAPIBaseURL(fsSvc), "org123", "my-model-slug")
-	err := downloadFile(url, "token", "test.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "test.hcl", false, fsSvc)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -715,7 +715,7 @@ func TestCloudThreatmodelDownloadThreatModelFileExists(t *testing.T) {
 
 	// Try to download without overwrite flag - should fail
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1")
-	err := downloadFile(url, "token", "existing.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "existing.hcl", false, fsSvc)
 
 	if err == nil {
 		t.Errorf("expected error when file exists without overwrite flag")
@@ -746,7 +746,7 @@ func TestCloudThreatmodelDownloadThreatModelFileExistsWithOverwrite(t *testing.T
 
 	// Try to download with overwrite flag - should succeed
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1")
-	err := downloadFile(url, "token", "existing.hcl", true, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "existing.hcl", true, fsSvc)
 
 	if err != nil {
 		t.Errorf("unexpected error with overwrite flag: %v", err)

--- a/cmd/threatcl/cloud_threatmodel_update_status.go
+++ b/cmd/threatcl/cloud_threatmodel_update_status.go
@@ -75,17 +75,14 @@ func (c *CloudThreatmodelUpdateStatusCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Step 1: Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Update threat model status
-	err = updateThreatmodelStatus(token, orgId, c.flagModelId, c.flagStatus, httpClient, fsSvc)
+	// Update threat model status
+	err = client.UpdateThreatmodelStatus(c.flagModelId, c.flagStatus)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error updating threat model status: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_threatmodel_versions.go
+++ b/cmd/threatcl/cloud_threatmodel_versions.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -88,19 +87,16 @@ func (c *CloudThreatmodelVersionsCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Step 1: Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, fsSvc, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Download threat model version file (if requested)
+	// Download threat model version file (if requested)
 	if c.flagDownload != "" {
-		apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(c.flagModelId), url.PathEscape(c.flagVersion))
-		err = downloadFile(apiURL, token, c.flagDownload, c.flagOverwrite, httpClient, fsSvc)
+		apiURL := client.DownloadModelVersionURL(c.flagModelId, c.flagVersion)
+		err = downloadToFile(client, apiURL, c.flagDownload, c.flagOverwrite, fsSvc)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error downloading threat model version file: %s\n", err)
 			return 1
@@ -109,8 +105,8 @@ func (c *CloudThreatmodelVersionsCommand) Run(args []string) int {
 		return 0
 	}
 
-	// Step 4: Fetch threat model versions
-	threatModelVersionsResponse, err := fetchThreatModelVersions(token, orgId, c.flagModelId, httpClient, fsSvc)
+	// Fetch threat model versions
+	threatModelVersionsResponse, err := client.FetchThreatModelVersions(c.flagModelId)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching threat model versions: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_threatmodel_versions_test.go
+++ b/cmd/threatcl/cloud_threatmodel_versions_test.go
@@ -282,7 +282,7 @@ func TestCloudThreatmodelVersionsFetchUserInfo(t *testing.T) {
 
 	_ = testCloudThreatmodelVersionsCommand(t, httpClient, nil, fsSvc)
 
-	resp, err := fetchUserInfo("token", httpClient, fsSvc)
+	resp, err := NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -328,7 +328,7 @@ func TestCloudThreatmodelVersionsFetchThreatModelVersions(t *testing.T) {
 
 	_ = testCloudThreatmodelVersionsCommand(t, httpClient, nil, fsSvc)
 
-	versions, err := fetchThreatModelVersions("token", "org123", "tm1", httpClient, fsSvc)
+	versions, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchThreatModelVersions("tm1")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -375,7 +375,7 @@ func TestCloudThreatmodelVersionsFetchThreatModelVersionsWithSlug(t *testing.T) 
 
 	_ = testCloudThreatmodelVersionsCommand(t, httpClient, nil, fsSvc)
 
-	versions, err := fetchThreatModelVersions("token", "org123", "my-model-slug", httpClient, fsSvc)
+	versions, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchThreatModelVersions("my-model-slug")
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -696,7 +696,7 @@ func TestCloudThreatmodelVersionsDownloadThreatModelVersion(t *testing.T) {
 	_ = testCloudThreatmodelVersionsCommand(t, httpClient, nil, fsSvc)
 
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1", "1.0.0")
-	err := downloadFile(url, "token", "test.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "test.hcl", false, fsSvc)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -723,7 +723,7 @@ func TestCloudThreatmodelVersionsDownloadThreatModelVersionWithSlug(t *testing.T
 	_ = testCloudThreatmodelVersionsCommand(t, httpClient, nil, fsSvc)
 
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download", getAPIBaseURL(fsSvc), "org123", "my-model-slug", "2.5.0")
-	err := downloadFile(url, "token", "test.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "test.hcl", false, fsSvc)
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -750,7 +750,7 @@ func TestCloudThreatmodelVersionsDownloadThreatModelVersionFileExists(t *testing
 
 	// Try to download without overwrite flag - should fail
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1", "1.0.0")
-	err := downloadFile(url, "token", "existing.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "existing.hcl", false, fsSvc)
 
 	if err == nil {
 		t.Errorf("expected error when file exists without overwrite flag")
@@ -781,7 +781,7 @@ func TestCloudThreatmodelVersionsDownloadThreatModelVersionFileExistsWithOverwri
 
 	// Try to download with overwrite flag - should succeed
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1", "3.0.0")
-	err := downloadFile(url, "token", "existing.hcl", true, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "existing.hcl", true, fsSvc)
 
 	if err != nil {
 		t.Errorf("unexpected error with overwrite flag: %v", err)
@@ -877,7 +877,7 @@ func TestCloudThreatmodelVersionsDownloadNotFoundError(t *testing.T) {
 	_ = testCloudThreatmodelVersionsCommand(t, httpClient, nil, fsSvc)
 
 	url := fmt.Sprintf("%s/api/v1/org/%s/models/%s/versions/%s/download", getAPIBaseURL(fsSvc), "org123", "tm1", "9.9.9")
-	err := downloadFile(url, "token", "test.hcl", false, httpClient, fsSvc)
+	err := downloadToFile(NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient), url, "test.hcl", false, fsSvc)
 
 	if err == nil {
 		t.Errorf("expected error for not found version")

--- a/cmd/threatcl/cloud_threatmodels.go
+++ b/cmd/threatcl/cloud_threatmodels.go
@@ -51,17 +51,14 @@ func (c *CloudThreatmodelsCommand) Run(args []string) int {
 	flagSet.StringVar(&c.flagOrgId, "org-id", "", "Organization ID (optional)")
 	flagSet.Parse(args)
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Step 1: Retrieve token and org ID
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Fetch threat models
-	threatModels, err := fetchThreatModels(token, orgId, httpClient, fsSvc)
+	// Fetch threat models
+	threatModels, err := client.FetchThreatModels()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching threat models: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_threatmodels_test.go
+++ b/cmd/threatcl/cloud_threatmodels_test.go
@@ -248,7 +248,7 @@ func TestCloudThreatmodelsFetchUserInfo(t *testing.T) {
 
 	_ = testCloudThreatmodelsCommand(t, httpClient, nil, fsSvc)
 
-	resp, err := fetchUserInfo("token", httpClient, fsSvc)
+	resp, err := NewCloudClient("token", "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -287,7 +287,7 @@ func TestCloudThreatmodelsFetchThreatModels(t *testing.T) {
 
 	_ = testCloudThreatmodelsCommand(t, httpClient, nil, fsSvc)
 
-	models, err := fetchThreatModels("token", "org123", httpClient, fsSvc)
+	models, err := NewCloudClient("token", "org123", getAPIBaseURL(fsSvc), httpClient).FetchThreatModels()
 
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/cmd/threatcl/cloud_token_add.go
+++ b/cmd/threatcl/cloud_token_add.go
@@ -73,9 +73,9 @@ func (c *CloudTokenAddCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Validate token and get user info
+	// Validate token and get user info (org-agnostic call)
 	fmt.Println("Validating token...")
-	whoamiResp, err := fetchUserInfo(token, httpClient, fsSvc)
+	whoamiResp, err := NewCloudClient(token, "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: invalid token or unable to connect to API: %s\n", err)
 		return 1

--- a/cmd/threatcl/cloud_upload.go
+++ b/cmd/threatcl/cloud_upload.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -121,16 +122,22 @@ func (c *CloudUploadCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Step 2: Retrieve token and org ID
+	// Retrieve token and org ID, then build the cloud client
 	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
+	client := NewCloudClient(token, orgId, getAPIBaseURL(fsSvc), httpClient)
 
-	// Step 3: Upload the file
-	err = uploadFile(token, orgId, c.flagModelId, filePath, false, httpClient, fsSvc)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error uploading file: %s\n", err)
+	// Upload the file. The caller reads it so the client stays filesystem-free.
+	content, uploadErr := fsSvc.ReadFile(filePath)
+	if uploadErr == nil {
+		uploadErr = client.Upload(c.flagModelId, filepath.Base(filePath), content, false)
+	} else {
+		uploadErr = fmt.Errorf("%s: %w", ErrFailedToReadFile, uploadErr)
+	}
+	if uploadErr != nil {
+		fmt.Fprintf(os.Stderr, "Error uploading file: %s\n", uploadErr)
 		return 1
 	}
 

--- a/cmd/threatcl/cloud_validate.go
+++ b/cmd/threatcl/cloud_validate.go
@@ -88,21 +88,24 @@ func (c *CloudValidateCommand) Run(args []string) int {
 		}
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-	token, _, err := c.getTokenAndOrgId("", keyringSvc, fsSvc)
+	// Build the cloud client. The org is resolved from the file's backend
+	// block, so start org-agnostic and re-scope with WithOrg once known.
+	client, _, err := c.newCloudClient("", 10*time.Second)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %s\n", err)
 		fmt.Fprintf(os.Stderr, "   %s\n", ErrPleaseLogin)
 		return 1
 	}
 
-	wrapped, orgValid, tmNameValid, tmFileMatchesVersion, err := validateThreatModel(token, filePath, httpClient, fsSvc, c.specCfg)
+	wrapped, orgValid, tmNameValid, tmFileMatchesVersion, err := validateThreatModel(client, filePath, c.specCfg)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %s\n", err)
 		return 1
 	}
+
+	// Scope a client to the resolved org for the ref-library lookups below.
+	orgClient := client.WithOrg(orgValid)
 
 	if tmFileMatchesVersion != "" {
 		fmt.Printf("✓ Local Threat model file matches the latest version of the cloud threat model at org-id: %s, model-id: %s, version: %s\n", orgValid, tmNameValid, tmFileMatchesVersion)
@@ -112,7 +115,7 @@ func (c *CloudValidateCommand) Run(args []string) int {
 	} else if tmNameValid != "" {
 		fmt.Printf("✓ Local Threat model file (org-id: %s, model-id: %s) matches a cloud threat model, but doesn't match the latest version\nConsider running 'threatcl cloud push' to update the local file to the latest version.\n", orgValid, tmNameValid)
 		if c.flagDiff {
-			if diffErr := runCloudValidateDiff(token, orgValid, tmNameValid, filePath, wrapped, httpClient, fsSvc, c.specCfg); diffErr != nil {
+			if diffErr := runCloudValidateDiff(orgClient, tmNameValid, filePath, wrapped, c.specCfg); diffErr != nil {
 				// Non-fatal: the validation result itself is unchanged.
 				fmt.Fprintf(os.Stderr, "⚠ Warning: could not produce diff: %s\n", diffErr)
 			}
@@ -131,7 +134,7 @@ func (c *CloudValidateCommand) Run(args []string) int {
 	if orgValid != "" && wrapped != nil {
 		refs := extractControlRefs(wrapped)
 		if len(refs) > 0 {
-			found, missing, refErr := validateControlRefs(token, orgValid, refs, httpClient, fsSvc)
+			found, missing, refErr := orgClient.ValidateControlRefs(refs)
 			if refErr != nil {
 				fmt.Fprintf(os.Stderr, "⚠ Warning: could not validate control refs: %s\n", refErr)
 			} else {
@@ -160,7 +163,7 @@ func (c *CloudValidateCommand) Run(args []string) int {
 	if orgValid != "" && wrapped != nil {
 		refs := extractThreatRefs(wrapped)
 		if len(refs) > 0 {
-			found, missing, refErr := validateThreatRefs(token, orgValid, refs, false, httpClient, fsSvc)
+			found, missing, refErr := orgClient.ValidateThreatRefs(refs, false)
 			if refErr != nil {
 				fmt.Fprintf(os.Stderr, "⚠ Warning: could not validate threat refs: %s\n", refErr)
 			} else {
@@ -189,7 +192,7 @@ func (c *CloudValidateCommand) Run(args []string) int {
 	if orgValid != "" && wrapped != nil {
 		refs := extractInformationAssetRefs(wrapped)
 		if len(refs) > 0 {
-			found, missing, refErr := validateInformationAssetRefs(token, orgValid, refs, httpClient, fsSvc)
+			found, missing, refErr := orgClient.ValidateInformationAssetRefs(refs)
 			if refErr != nil {
 				fmt.Fprintf(os.Stderr, "⚠ Warning: could not validate information asset refs: %s\n", refErr)
 			} else {

--- a/cmd/threatcl/cloud_validate_diff.go
+++ b/cmd/threatcl/cloud_validate_diff.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -23,10 +22,9 @@ import (
 // in the cloud version, removals ("-") are cloud-only, and "~" marks entities
 // present in both but changed.
 func runCloudValidateDiff(
-	token, orgId, modelIdOrSlug, filePath string,
+	client *CloudClient,
+	modelIdOrSlug, filePath string,
 	localWrapped *spec.ThreatmodelWrapped,
-	httpClient HTTPClient,
-	fsSvc FileSystemService,
 	specCfg *spec.ThreatmodelSpecConfig,
 ) error {
 	// Re-read the raw local bytes (the same content validateThreatModel hashed).
@@ -36,12 +34,7 @@ func runCloudValidateDiff(
 	}
 
 	// Download the current cloud HCL. URL shape matches 'cloud export'.
-	downloadURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download",
-		getAPIBaseURL(fsSvc),
-		url.PathEscape(orgId),
-		url.PathEscape(modelIdOrSlug),
-	)
-	cloudRaw, err := downloadFileContent(downloadURL, token, httpClient)
+	cloudRaw, err := client.DownloadContent(client.DownloadModelURL(modelIdOrSlug))
 	if err != nil {
 		return fmt.Errorf("downloading cloud version: %w", err)
 	}

--- a/cmd/threatcl/cloud_view.go
+++ b/cmd/threatcl/cloud_view.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,9 +132,9 @@ func (c *CloudViewCommand) Run(args []string) int {
 		}
 	}
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-	token, orgId, err := c.getTokenAndOrgId(c.flagOrgId, keyringSvc, fsSvc)
+	// Build the cloud client. The construction org is used for the cloud
+	// download below; ref enrichment re-scopes with WithOrg(orgValid).
+	client, _, err := c.newCloudClient(c.flagOrgId, 10*time.Second)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		fmt.Fprintf(os.Stderr, "   %s\n", ErrPleaseLogin)
@@ -147,24 +146,10 @@ func (c *CloudViewCommand) Run(args []string) int {
 	var tmpDir string
 
 	if c.flagModelId != "" {
-		// Download from cloud to a temp file
-		apiURL := fmt.Sprintf("%s/api/v1/org/%s/models/%s/download", getAPIBaseURL(fsSvc), url.PathEscape(orgId), url.PathEscape(c.flagModelId))
-		resp, dlErr := makeAuthenticatedRequest("GET", apiURL, token, nil, httpClient)
+		// Download from cloud to a temp file (construction-org client)
+		body, dlErr := client.DownloadContent(client.DownloadModelURL(c.flagModelId))
 		if dlErr != nil {
 			fmt.Fprintf(os.Stderr, "Error downloading threat model: %s\n", dlErr)
-			return 1
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			errResp := handleAPIErrorResponse(resp)
-			fmt.Fprintf(os.Stderr, "Error downloading threat model: %s\n", errResp)
-			return 1
-		}
-
-		body, readErr := io.ReadAll(resp.Body)
-		if readErr != nil {
-			fmt.Fprintf(os.Stderr, "Error reading download response: %s\n", readErr)
 			return 1
 		}
 
@@ -191,18 +176,21 @@ func (c *CloudViewCommand) Run(args []string) int {
 	}
 
 	// Validate threat model (reuse existing validateThreatModel)
-	wrapped, orgValid, _, _, err := validateThreatModel(token, filePath, httpClient, fsSvc, c.specCfg)
+	wrapped, orgValid, _, _, err := validateThreatModel(client, filePath, c.specCfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		return 1
 	}
+
+	// Scope a client to the resolved org for the ref enrichment below.
+	orgClient := client.WithOrg(orgValid)
 
 	// If org is valid, check for control refs and enrich if needed
 	if orgValid != "" && wrapped != nil {
 		refs := extractControlRefs(wrapped)
 		if len(refs) > 0 {
 			// Fetch control data from cloud
-			found, missing, refErr := validateControlRefs(token, orgValid, refs, httpClient, fsSvc)
+			found, missing, refErr := orgClient.ValidateControlRefs(refs)
 			if refErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: could not fetch control refs: %s\n", refErr)
 			} else {
@@ -222,7 +210,7 @@ func (c *CloudViewCommand) Run(args []string) int {
 		if len(threatRefs) > 0 {
 			// Fetch threat data from cloud (include recommended controls unless flag is set)
 			includeLinkedControls := !c.flagIgnoreLinkedControls
-			foundThreats, missingThreats, threatErr := validateThreatRefs(token, orgValid, threatRefs, includeLinkedControls, httpClient, fsSvc)
+			foundThreats, missingThreats, threatErr := orgClient.ValidateThreatRefs(threatRefs, includeLinkedControls)
 			if threatErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: could not fetch threat refs: %s\n", threatErr)
 			} else {
@@ -240,7 +228,7 @@ func (c *CloudViewCommand) Run(args []string) int {
 		// Check for information asset refs and enrich if needed
 		assetRefs := extractInformationAssetRefs(wrapped)
 		if len(assetRefs) > 0 {
-			foundAssets, missingAssets, assetErr := validateInformationAssetRefs(token, orgValid, assetRefs, httpClient, fsSvc)
+			foundAssets, missingAssets, assetErr := orgClient.ValidateInformationAssetRefs(assetRefs)
 			if assetErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: could not fetch information asset refs: %s\n", assetErr)
 			} else {

--- a/cmd/threatcl/cloud_whoami.go
+++ b/cmd/threatcl/cloud_whoami.go
@@ -50,24 +50,21 @@ func (c *CloudWhoamiCommand) Run(args []string) int {
 	flagSet.StringVar(&orgIdFlag, "org-id", "", "Organization ID")
 	flagSet.Parse(args)
 
-	// Initialize dependencies
-	httpClient, keyringSvc, fsSvc := c.initDependencies(10 * time.Second)
-
-	// Step 1: Retrieve token for the specified/default org
-	token, orgId, err := c.getTokenAndOrgId(orgIdFlag, keyringSvc, fsSvc)
+	// Build the cloud client (resolves token + org)
+	client, _, err := c.newCloudClient(orgIdFlag, 10*time.Second)
 	if err != nil {
 		return c.handleTokenError(err)
 	}
 
-	// Step 2: Make API request
-	whoamiResp, err := fetchUserInfo(token, httpClient, fsSvc)
+	// Make API request
+	whoamiResp, err := client.FetchUserInfo()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error fetching user information: %s\n", err)
 		return 1
 	}
 
-	// Step 3: Display results
-	c.displayUserInfo(whoamiResp, orgId)
+	// Display results
+	c.displayUserInfo(whoamiResp, client.OrgID())
 
 	return 0
 }

--- a/cmd/threatcl/cloud_whoami_test.go
+++ b/cmd/threatcl/cloud_whoami_test.go
@@ -146,7 +146,7 @@ func TestCloudWhoamiFetchUserInfo(t *testing.T) {
 
 			_ = testCloudWhoamiCommand(t, httpClient, nil, fsSvc)
 
-			resp, err := fetchUserInfo(tt.token, httpClient, fsSvc)
+			resp, err := NewCloudClient(tt.token, "", getAPIBaseURL(fsSvc), httpClient).FetchUserInfo()
 
 			if tt.expectError {
 				if err == nil {


### PR DESCRIPTION
## Candidate 1 — Collapse the cloud API into one deep client

Part of the architecture-review deepening opportunities (candidate **01**, _Strong_).

<img width="1053" height="959" alt="Screenshot 2026-07-04 at 12 12 38 pm" src="https://github.com/user-attachments/assets/a5b18f6c-cf6f-4d66-9c79-cb9cae954e03" />


### Problem
Every cloud call threaded `token, orgId, httpClient, fsSvc` by hand; the cloud "API" was ~28 free functions with URL-building and status→error handling duplicated — and inconsistent — across them. Command tests stood up three fakes per case (~6:1 arrange-to-logic).

### What changed
- New **`CloudClient`** deep module (`cloud_client.go`): captures `token`, `orgId`, `baseURL`, and transport at construction; `WithOrg` returns a re-scoped copy for file-resolved orgs; adds `DownloadModelURL`/`DownloadModelVersionURL`.
- Converted ~28 free functions in `cloud_api_helpers.go` / `cloud_policy_api_helpers.go` into `CloudClient` methods; URL building and status→error mapping now live behind the client.
- Added `CloudCommandBase.newCloudClient` to collapse the per-command `initDependencies → getTokenAndOrgId → handleTokenError` boilerplate; migrated **24** command files.
- `Upload` takes bytes (callers read the file) so the client stays filesystem-free; `downloadToFile` holds the overwrite-check + write path.
- `validateThreatModel` / `cloud push` / `cloud validate` / `cloud view` resolve the org from the file's backend block and re-scope via `client.WithOrg`.
- New `cloud_client_test.go`: exact URL/method/`Authorization` header, error mapping (401 / custom-404 / 500), `WithOrg`, multipart upload, ref validation, 201-only evaluate.

### Wins
- interface shrinks; implementation absorbs the threading
- locality: status→error handled in one place
- leverage: one client, ~45 call sites
- tests fake one client, not three services

### Testing
`go build ./...`, `go vet ./cmd/threatcl/`, `gofmt -l` (clean), and full `go test ./...` all green. Existing behavior and error strings preserved.

---
Draft stacked series: **1/4 CloudClient** → 2 threat-model repository → 3 output-sink → 4 spec→GraphQL mapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
