### PR TITLE
refactor(loader): extract one threat-model load-and-parse seam (2/4)

### DIFF
--- a/cmd/threatcl/util.go
+++ b/cmd/threatcl/util.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/posener/complete"
 	"github.com/threatcl/spec"
+	"github.com/threatcl/threatcl/internal/tmloader"
 )
 
 // Autocomplete predictors for files and directories
@@ -413,11 +414,11 @@ func prettyBoolFromString(in string) bool {
 	return in == "Yes"
 }
 
-// findAllFiles wraps Json and Hcl file finding
+// findAllFiles wraps Json and Hcl file finding. Discovery lives in the shared
+// tmloader seam so the cache and the CLI commands agree on what counts as a
+// threat model file.
 func findAllFiles(files []string) []string {
-	out := findHclFiles(files)
-	out = append(out, findJsonFiles(files)...)
-	return out
+	return tmloader.FindFiles(files)
 }
 
 // fileExistenceCheck checks for the existence of provided files
@@ -431,68 +432,6 @@ func fileExistenceCheck(outfiles []string, overwrite bool) error {
 		}
 	}
 	return nil
-}
-
-// findJsonFiles iterates through a list of files or folders
-// looking for .json files
-// currently it does this recursively through folders too
-func findJsonFiles(files []string) []string {
-	out := []string{}
-	recurse := true // @TODO potentially in the future we may make this an argument / flag
-	for _, file := range files {
-		info, err := os.Stat(file)
-		if !os.IsNotExist(err) {
-			if !info.IsDir() {
-				if filepath.Ext(file) == ".json" {
-					out = append(out, file)
-				}
-			} else {
-				if recurse {
-					re_err := filepath.Walk(file, func(path string, re_info os.FileInfo, err error) error {
-						if !re_info.IsDir() && filepath.Ext(path) == ".json" {
-							out = append(out, path)
-						}
-						return nil
-					})
-					if re_err != nil {
-						panic(re_err) // @TODO - handle this error better
-					}
-				}
-			}
-		}
-	}
-	return out
-}
-
-// findHclFiles iterates through a list of files or folders
-// looking for .hcl files
-// currently it does this recursively through folders too
-func findHclFiles(files []string) []string {
-	out := []string{}
-	recurse := true // @TODO potentially in the future we may make this an argument / flag
-	for _, file := range files {
-		info, err := os.Stat(file)
-		if !os.IsNotExist(err) {
-			if !info.IsDir() {
-				if filepath.Ext(file) == ".hcl" {
-					out = append(out, file)
-				}
-			} else {
-				if recurse {
-					re_err := filepath.Walk(file, func(path string, re_info os.FileInfo, err error) error {
-						if !re_info.IsDir() && filepath.Ext(path) == ".hcl" {
-							out = append(out, path)
-						}
-						return nil
-					})
-					if re_err != nil {
-						panic(re_err) // @TODO - handle this error better
-					}
-				}
-			}
-		}
-	}
-	return out
 }
 
 func configFileLocation() (string, error) {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -2,11 +2,10 @@ package cache
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/threatcl/spec"
+	"github.com/threatcl/threatcl/internal/tmloader"
 )
 
 // ThreatModelCache provides thread-safe in-memory storage for parsed threat models
@@ -40,8 +39,8 @@ func (c *ThreatModelCache) LoadAll() error {
 	c.fileToModel = make(map[string][]string)
 	c.modelToFile = make(map[string]string)
 
-	// Find all HCL and JSON files
-	files := c.findAllFiles([]string{c.rootDir})
+	// Find all HCL and JSON files via the shared loader seam
+	files := tmloader.FindFiles([]string{c.rootDir})
 
 	// Parse each file
 	for _, file := range files {
@@ -56,15 +55,9 @@ func (c *ThreatModelCache) LoadAll() error {
 // loadFile parses a single file and adds its threat models to the cache
 // Note: This method is NOT thread-safe and should only be called from within locked sections
 func (c *ThreatModelCache) loadFile(filepath string) error {
-	tmParser := spec.NewThreatmodelParser(c.specCfg)
-	err := tmParser.ParseFile(filepath, false)
+	wrapped, err := tmloader.ParseFile(c.specCfg, filepath)
 	if err != nil {
 		return err
-	}
-
-	wrapped := tmParser.GetWrapped()
-	if wrapped == nil {
-		return fmt.Errorf("no threat models found in %s", filepath)
 	}
 
 	modelNames := []string{}
@@ -145,68 +138,6 @@ func (c *ThreatModelCache) GetSourceFile(modelName string) (string, bool) {
 
 	filepath, exists := c.modelToFile[modelName]
 	return filepath, exists
-}
-
-// findAllFiles wraps Json and Hcl file finding
-// This is adapted from cmd/threatcl/util.go
-func (c *ThreatModelCache) findAllFiles(files []string) []string {
-	out := c.findHclFiles(files)
-	out = append(out, c.findJsonFiles(files)...)
-	return out
-}
-
-// findJsonFiles iterates through a list of files or folders looking for .json files
-func (c *ThreatModelCache) findJsonFiles(files []string) []string {
-	out := []string{}
-	for _, file := range files {
-		info, err := os.Stat(file)
-		if !os.IsNotExist(err) {
-			if !info.IsDir() {
-				if filepath.Ext(file) == ".json" {
-					out = append(out, file)
-				}
-			} else {
-				// Recursively walk directory
-				filepath.Walk(file, func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if !info.IsDir() && filepath.Ext(path) == ".json" {
-						out = append(out, path)
-					}
-					return nil
-				})
-			}
-		}
-	}
-	return out
-}
-
-// findHclFiles iterates through a list of files or folders looking for .hcl files
-func (c *ThreatModelCache) findHclFiles(files []string) []string {
-	out := []string{}
-	for _, file := range files {
-		info, err := os.Stat(file)
-		if !os.IsNotExist(err) {
-			if !info.IsDir() {
-				if filepath.Ext(file) == ".hcl" {
-					out = append(out, file)
-				}
-			} else {
-				// Recursively walk directory
-				filepath.Walk(file, func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if !info.IsDir() && filepath.Ext(path) == ".hcl" {
-						out = append(out, path)
-					}
-					return nil
-				})
-			}
-		}
-	}
-	return out
 }
 
 // GetFileToModelMapping returns a copy of the file-to-model mapping for debugging

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -180,30 +180,6 @@ func TestGetFileToModelMapping(t *testing.T) {
 	}
 }
 
-func TestFindHclFiles(t *testing.T) {
-	examplesDir := filepath.Join("..", "..", "examples")
-
-	if _, err := os.Stat(examplesDir); os.IsNotExist(err) {
-		t.Skip("Examples directory not found, skipping test")
-	}
-
-	cfg := &spec.ThreatmodelSpecConfig{}
-	cache := NewThreatModelCache(cfg, examplesDir)
-
-	files := cache.findHclFiles([]string{examplesDir})
-	if len(files) == 0 {
-		t.Error("Expected to find at least one HCL file")
-	}
-
-	for _, file := range files {
-		if filepath.Ext(file) != ".hcl" {
-			t.Errorf("Expected only .hcl files, got %s", file)
-		}
-	}
-
-	t.Logf("Found %d HCL files", len(files))
-}
-
 func TestConcurrentAccess(t *testing.T) {
 	examplesDir := filepath.Join("..", "..", "examples")
 

--- a/internal/tmloader/tmloader.go
+++ b/internal/tmloader/tmloader.go
@@ -1,0 +1,88 @@
+// Package tmloader is the single seam for turning a set of paths (files or
+// directories) into parsed threat models. Both the long-running cache
+// (internal/cache, used by the server and query commands) and the one-shot CLI
+// commands (view, dfd, mermaid, export, dashboard, list, validate) discover and
+// parse threat model files — previously each had its own copy of the file-walk
+// logic. Concentrating discovery (FindFiles) and parsing (Load) here means the
+// rules for "what counts as a threat model file" and "how a file becomes a set
+// of threat models" live in one place.
+package tmloader
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/threatcl/spec"
+)
+
+// FindFiles expands a list of paths (files or directories) into the set of
+// threat model source files (.hcl and .json). Directories are walked
+// recursively. Paths that don't exist are skipped. HCL files are returned
+// before JSON files, preserving the previous cmd/threatcl ordering.
+func FindFiles(paths []string) []string {
+	out := findByExt(paths, ".hcl")
+	out = append(out, findByExt(paths, ".json")...)
+	return out
+}
+
+func findByExt(paths []string, ext string) []string {
+	out := []string{}
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			if filepath.Ext(p) == ext {
+				out = append(out, p)
+			}
+			continue
+		}
+		// Recurse into directories, skipping entries we can't walk.
+		_ = filepath.Walk(p, func(path string, wi os.FileInfo, werr error) error {
+			if werr != nil {
+				return nil
+			}
+			if !wi.IsDir() && filepath.Ext(path) == ext {
+				out = append(out, path)
+			}
+			return nil
+		})
+	}
+	return out
+}
+
+// Load discovers every threat model source under paths and parses each one,
+// returning the combined set of threat models. A parse failure on any file
+// stops the load and returns an error naming that file (matching the cache's
+// previous behavior). The returned slice preserves file-discovery order.
+func Load(specCfg *spec.ThreatmodelSpecConfig, paths []string) ([]*spec.Threatmodel, error) {
+	var models []*spec.Threatmodel
+	for _, file := range FindFiles(paths) {
+		wrapped, err := ParseFile(specCfg, file)
+		if err != nil {
+			return nil, fmt.Errorf("error loading %s: %w", file, err)
+		}
+		for i := range wrapped.Threatmodels {
+			models = append(models, &wrapped.Threatmodels[i])
+		}
+	}
+	return models, nil
+}
+
+// ParseFile parses a single threat model file into its wrapped representation.
+func ParseFile(specCfg *spec.ThreatmodelSpecConfig, path string) (*spec.ThreatmodelWrapped, error) {
+	parser := spec.NewThreatmodelParser(specCfg)
+	if err := parser.ParseFile(path, false); err != nil {
+		return nil, err
+	}
+	wrapped := parser.GetWrapped()
+	if wrapped == nil {
+		return nil, fmt.Errorf("no threat models found in %s", path)
+	}
+	return wrapped, nil
+}

--- a/internal/tmloader/tmloader_test.go
+++ b/internal/tmloader/tmloader_test.go
@@ -1,0 +1,98 @@
+package tmloader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/threatcl/spec"
+)
+
+func TestFindFiles(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(p string) {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(dir, "a.hcl"))
+	write(filepath.Join(dir, "b.json"))
+	write(filepath.Join(dir, "ignore.txt"))
+	write(filepath.Join(sub, "c.hcl"))
+
+	got := FindFiles([]string{dir})
+
+	var hcl, jsonc, txt int
+	for _, f := range got {
+		switch filepath.Ext(f) {
+		case ".hcl":
+			hcl++
+		case ".json":
+			jsonc++
+		case ".txt":
+			txt++
+		}
+	}
+	if hcl != 2 {
+		t.Errorf("hcl files = %d, want 2 (incl. recursion): %v", hcl, got)
+	}
+	if jsonc != 1 {
+		t.Errorf("json files = %d, want 1: %v", jsonc, got)
+	}
+	if txt != 0 {
+		t.Errorf(".txt should be excluded, got %v", got)
+	}
+	// HCL files should come before JSON files.
+	if len(got) == 3 && filepath.Ext(got[len(got)-1]) != ".json" {
+		t.Errorf("expected JSON last, got order %v", got)
+	}
+}
+
+func TestFindFilesSkipsNonexistent(t *testing.T) {
+	got := FindFiles([]string{filepath.Join(t.TempDir(), "does-not-exist")})
+	if len(got) != 0 {
+		t.Errorf("nonexistent path should yield no files, got %v", got)
+	}
+}
+
+func TestFindFilesExplicitFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "one.hcl")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := FindFiles([]string{p})
+	if len(got) != 1 || got[0] != p {
+		t.Errorf("explicit file = %v, want [%s]", got, p)
+	}
+}
+
+// TestLoadExamples exercises discovery + parse against the repo's real examples.
+func TestLoadExamples(t *testing.T) {
+	examplesDir := filepath.Join("..", "..", "examples")
+	if _, err := os.Stat(examplesDir); os.IsNotExist(err) {
+		t.Skip("examples directory not found")
+	}
+
+	cfg, err := spec.LoadSpecConfig()
+	if err != nil {
+		t.Fatalf("load spec config: %v", err)
+	}
+
+	models, err := Load(cfg, []string{examplesDir})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(models) == 0 {
+		t.Error("expected at least one threat model from examples")
+	}
+	for _, m := range models {
+		if m == nil {
+			t.Error("nil threat model in Load result")
+		}
+	}
+}


### PR DESCRIPTION
## Candidate 2 — One load-and-parse seam for threat models

Part of the architecture-review deepening opportunities (candidate **02**, _Strong_). **Stacked on #174** — until that merges, GitHub's diff here also shows candidate 1's changes (a limitation of stacking from a fork). The files belonging to **this** candidate are listed below.

<img width="1021" height="683" alt="Screenshot 2026-07-04 at 12 14 59 pm" src="https://github.com/user-attachments/assets/31499765-1254-4b15-80b7-9b68316a44c8" />


### Problem
`internal/cache` (used by `server` and `query`) and the CLI commands each carried **their own copy of the file-discovery walk** — `cache.go`'s `find*` was literally commented "adapted from `cmd/threatcl/util.go`". Two implementations of "what counts as a threat model file", in two packages.

### What changed (candidate-2 files)
- **`internal/tmloader/tmloader.go`** (new): the single seam — `FindFiles` (discovery), `Load` (discovery + parse → `[]*spec.Threatmodel`), and `ParseFile`.
- **`internal/tmloader/tmloader_test.go`** (new): discovery (recursion, extension filtering, ordering, nonexistent paths) + load-against-examples.
- **`internal/cache/cache.go`**: `LoadAll`/`loadFile` now go through `tmloader`; the duplicate `find*` methods removed.
- **`cmd/threatcl/util.go`**: `findAllFiles` delegates to `tmloader.FindFiles`, so all seven local commands' discovery flows through one implementation; duplicate `findHclFiles`/`findJsonFiles` removed.
- **`internal/cache/cache_test.go`**: dropped the test of the now-removed private method (coverage moved to `tmloader_test.go`).

### Scope note
On inspection, MCP's per-request parsing operates on HCL **passed as tool arguments**, not a re-read directory — so it is *not* a missing cache adapter, and is intentionally left as-is. The broader consolidation of each command's discover-then-parse loop onto `tmloader.Load` is a natural follow-up on top of this seam.

### Wins
- file discovery stops being duplicated across two packages
- one place defines "what is a threat model file"
- locality: parse + discovery rules live in one seam
- net **−163 / +195** lines, most of it deletion

### Testing
`go build ./...`, `gofmt -l` (clean), full `go test ./...` green (incl. new `internal/tmloader`).

---
Draft stacked series: 1 CloudClient (#174) → **2/4 load-and-parse seam** → 3 output-sink → 4 spec→GraphQL mapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
