### PR TITLE
refactor(render): one shared file writer for the render commands (3/4)

### DIFF
--- a/cmd/threatcl/dfd.go
+++ b/cmd/threatcl/dfd.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/posener/complete"
@@ -125,14 +124,7 @@ func (c *DfdCommand) writeSingle(allFiles []string, index int) int {
 			fmt.Printf("Error fetching DFD for output: %s\n", err)
 			return 1
 		}
-		f, err := os.Create(c.flagOutFile)
-		if err != nil {
-			fmt.Printf("Error creating file: %s: %s\n", c.flagOutFile, err)
-			return 1
-		}
-		defer f.Close()
-
-		if _, err := f.WriteString(text); err != nil {
+		if err := writeStringToFile(c.flagOutFile, text); err != nil {
 			fmt.Printf("Error writing %s file to %s: %s\n", strings.ToUpper(c.flagFormat), c.flagOutFile, err)
 			return 1
 		}
@@ -413,14 +405,7 @@ func (c *DfdCommand) Run(args []string) int {
 							return 1
 						}
 
-						f, err := os.Create(currentOutpath)
-						if err != nil {
-							fmt.Printf("Error creating file: %s: %s\n", currentOutpath, err)
-							return 1
-						}
-						defer f.Close()
-
-						if _, err := f.WriteString(text); err != nil {
+						if err := writeStringToFile(currentOutpath, text); err != nil {
 							fmt.Printf("Error writing %s file to %s: %s\n", strings.ToUpper(c.flagFormat), currentOutpath, err)
 							return 1
 						}

--- a/cmd/threatcl/export.go
+++ b/cmd/threatcl/export.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/posener/complete"
@@ -101,15 +100,7 @@ func (e *ExportCommand) Run(args []string) int {
 				return 1
 			}
 
-			f, err := os.Create(e.flagOutput)
-			if err != nil {
-				fmt.Printf("Error creating file: %s: %s\n", e.flagOutput, err)
-				return 1
-			}
-			defer f.Close()
-
-			_, err = f.WriteString(outputString)
-			if err != nil {
+			if err := writeStringToFile(e.flagOutput, outputString); err != nil {
 				fmt.Printf("Error writing output to %s: %s\n", e.flagOutput, err)
 				return 1
 			}
@@ -127,9 +118,9 @@ func (e *ExportCommand) Synopsis() string {
 func (c *ExportCommand) AutocompleteArgs() complete.Predictor { return predictHCLOrJSON }
 func (c *ExportCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-config":    predictHCL,
-		"-format":    complete.PredictSet("json", "otm", "hcl"),
-		"-output":    complete.PredictFiles("*"),
-		"-template":  predictTpl,
+		"-config":   predictHCL,
+		"-format":   complete.PredictSet("json", "otm", "hcl"),
+		"-output":   complete.PredictFiles("*"),
+		"-template": predictTpl,
 	}
 }

--- a/cmd/threatcl/mermaid.go
+++ b/cmd/threatcl/mermaid.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/posener/complete"
@@ -115,14 +114,7 @@ func printTooMany(entries []mermaidEntry, destination string) {
 
 // writeMermaidFile writes a single mermaid block to path.
 func (c *MermaidCommand) writeMermaidFile(path, content string) int {
-	f, err := os.Create(path)
-	if err != nil {
-		fmt.Printf("Error creating file: %s: %s\n", path, err)
-		return 1
-	}
-	defer f.Close()
-
-	if _, err := f.WriteString(mermaidSource(content)); err != nil {
+	if err := writeStringToFile(path, mermaidSource(content)); err != nil {
 		fmt.Printf("Error writing mermaid file to %s: %s\n", path, err)
 		return 1
 	}

--- a/cmd/threatcl/util.go
+++ b/cmd/threatcl/util.go
@@ -421,6 +421,24 @@ func findAllFiles(files []string) []string {
 	return tmloader.FindFiles(files)
 }
 
+// writeStringToFile creates (truncating any existing file) path and writes
+// content to it, closing the file before returning. It is the single place the
+// render commands (dfd, mermaid, export) turn a rendered string into a file, so
+// the create + write + close dance isn't copied at each call site (dfd alone
+// had two copies, one of which leaked a per-iteration defer inside a loop).
+func writeStringToFile(path, content string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(content); err != nil {
+		return err
+	}
+	return nil
+}
+
 // fileExistenceCheck checks for the existence of provided files
 func fileExistenceCheck(outfiles []string, overwrite bool) error {
 	if !overwrite {


### PR DESCRIPTION
## Candidate 3 — A shared writer for the render commands

Part of the architecture-review deepening opportunities (candidate **03**, _Worth exploring_). **Stacked on #176** — GitHub's diff also shows candidates 1 & 2 until those merge (fork-stacking limitation). This candidate's files: `cmd/threatcl/util.go`, `dfd.go`, `mermaid.go`, `export.go`.

<img width="1091" height="842" alt="Screenshot 2026-07-04 at 12 17 33 pm" src="https://github.com/user-attachments/assets/40258002-fac7-4ae1-a4a0-b95e68241450" />


### Problem
`dfd`, `mermaid` and `export` each hand-rolled the same `os.Create → WriteString → Close` dance to turn a rendered string into a file. `dfd` had **two** copies, and its directory-loop copy leaked a per-iteration `defer f.Close()` **inside the loop** (handles accumulate until the whole command returns).

### What changed
- **`util.go`**: new `writeStringToFile(path, content)` — the single place a render command turns a string into a file (create + write + close).
- **`dfd.go`**: `writeSingle` and the directory loop both go through it; the loop-defer bug is gone (the helper closes per call).
- **`mermaid.go`**: `writeMermaidFile` delegates to it.
- **`export.go`**: the file branch delegates to it.

Success/error output is unchanged — callers keep their own `Successfully created`/`Successfully wrote` and error messages; only the create/write boilerplate moved.

### Scope note
This consolidates the **write leaf** (the concrete duplication in the review). The fuller `OutputSink` seam with distinct stdout / file / directory adapters — routing each command's destination dispatch through one interface — is the natural next step on top of this.

### Wins
- render commands stop re-implementing the write path
- one place owns create + write + close
- fixes a latent loop-`defer` file-handle leak in dfd
- net **−14** lines

### Testing
`go build ./...`, `gofmt -l` (clean), full `go test ./...` green. The dfd/mermaid/export tests that assert `Successfully created`/`Successfully wrote` still pass.

---
Draft stacked series: 1 CloudClient (#174) → 2 load-and-parse (#176) → **3/4 shared writer** → 4 spec→GraphQL mapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
