### PR TITLE
build(docker): cut the runtime image over to FROM scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.25.9-alpine3.23 AS builder
+# Local from-source image build (`make image`). The released image is built
+# from Dockerfile.goreleaser instead; both use the same `FROM scratch` runtime
+# shape (static binary + CA certs + nonroot passwd/group from an alpine donor).
+FROM golang:1.25.11-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c9 AS builder
 
 RUN apk update
 RUN apk upgrade
@@ -8,12 +11,22 @@ COPY . .
 ENV CGO_ENABLED=0
 RUN go build -o threatcl ./cmd/threatcl
 
-FROM alpine:3.24 AS threatcl
-
-MAINTAINER Christian Frichot <xntrik@gmail.com>
-LABEL org.opencontainers.image.authors="Christian Frichot <xntrik@gmail.com>"
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS donor
 
 RUN addgroup -S threatcl && adduser -S -G threatcl threatcl
+
+FROM scratch AS threatcl
+
+LABEL org.opencontainers.image.authors="Christian Frichot <xntrik@gmail.com>"
+
+COPY --from=donor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=donor /etc/passwd /etc/passwd
+COPY --from=donor /etc/group /etc/group
+
+# scratch has no /tmp or home dir; the remote-imports loader stages downloads
+# under os.TempDir(). Owned by the nonroot user so both are writable.
+COPY --from=donor --chown=threatcl:threatcl /tmp /tmp
+COPY --from=donor --chown=threatcl:threatcl /home/threatcl /home/threatcl
 
 WORKDIR /app
 COPY --from=builder /src/threatcl /bin/threatcl

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -6,12 +6,33 @@
 # the pre-built binary (no build stage); the binary is byte-identical to the one
 # in the released archive.
 #
+# The runtime is `FROM scratch`: the binary is fully static (CGO_ENABLED=0),
+# so beyond it the image only needs CA certificates (TLS to Threatcl Cloud and
+# remote `imports` in threat model files) and passwd/group entries for the
+# nonroot user. A digest-pinned alpine donor stage provides those three files;
+# nothing else from alpine (musl, busybox, apk, openssl) ships in the final
+# image — no shell, no package manager, effectively no base-layer CVE surface.
+# Trade-off: `docker exec` into a running container is no longer possible.
+#
 # For local from-source image builds use the top-level `Dockerfile` (`make image`).
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS donor
+
+RUN addgroup -S threatcl && adduser -S -G threatcl threatcl
+
+FROM scratch
 
 ARG TARGETPLATFORM
 
-RUN addgroup -S threatcl && adduser -S -G threatcl threatcl
+# ca-certificates.crt comes from alpine's ca-certificates-bundle package,
+# which is part of the base image (no apk install — no network at build time).
+COPY --from=donor /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=donor /etc/passwd /etc/passwd
+COPY --from=donor /etc/group /etc/group
+
+# scratch has no /tmp or home dir; the remote-imports loader stages downloads
+# under os.TempDir(). Owned by the nonroot user so both are writable.
+COPY --from=donor --chown=threatcl:threatcl /tmp /tmp
+COPY --from=donor --chown=threatcl:threatcl /home/threatcl /home/threatcl
 
 COPY $TARGETPLATFORM/threatcl /usr/bin/threatcl
 


### PR DESCRIPTION
## What

Follow-up to #179 (the `FROM scratch` option discussed there). The threatcl binary is fully static (`CGO_ENABLED=0`), so the alpine runtime layer was pure CVE/attack surface — musl, busybox, apk, openssl, none of it used by the binary. Both the GoReleaser runtime image ([Dockerfile.goreleaser](Dockerfile.goreleaser)) and the local from-source image ([Dockerfile](Dockerfile)) now run `FROM scratch`, with a digest-pinned alpine **donor stage** providing the only five paths the binary needs:

- `/etc/ssl/certs/ca-certificates.crt` — TLS to Threatcl Cloud and remote `imports` in threat model files (comes from alpine's base `ca-certificates-bundle`; no `apk add`, so no network at image-build time)
- `/etc/passwd` + `/etc/group` — the nonroot `USER threatcl`
- `/tmp` + `/home/threatcl`, owned by the nonroot user — **found by testing**: the remote-imports loader stages downloads under `os.TempDir()`, and scratch ships no `/tmp` (`stat /tmp: no such file or directory` without it)

## Trade-offs

- No shell / package manager: `docker exec` debugging into a running container is no longer possible.
- Image scanners now see just the binary — the weekly Trivy scan from #179 goes near-silent by construction.
- Size: 91.6MB (published alpine-based `:latest`) → 77.6MB.

## Validation (local)

- From-source build (`Dockerfile`) and a GoReleaser-shaped per-platform context build (`Dockerfile.goreleaser`, `linux/arm64` layout as `dockers_v2` lays it out) both:
  - run as `user=threatcl` with the correct entrypoint,
  - pass `threatcl validate examples/tm3.hcl`, whose HTTPS imports exercise CA certs, DNS, and `/tmp` end-to-end.
- Exported filesystem contains exactly the intended paths (certs, passwd/group, tmp, home, binary).
- The PR `validate` check builds both platforms' images via the GoReleaser snapshot dry-run.

## Note on #179

Both PRs touch the two Dockerfiles (#179 digest-pins the alpine/golang bases; this branch already carries those digests plus the Go 1.25.11 builder). Whichever merges second needs a trivial rebase — resolution is "take this branch's version" of both files. The deprecated `MAINTAINER` line is dropped (OCI `authors` label stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)