### PR TITLE
fix(dashboard): sanitize HTML output to prevent stored XSS

### DIFF
--- a/cmd/threatcl/dashboard.go
+++ b/cmd/threatcl/dashboard.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
 	"io"
@@ -10,8 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/microcosm-cc/bluemonday"
 	"github.com/posener/complete"
 	"github.com/threatcl/spec"
+	"github.com/yuin/goldmark"
 )
 
 type tmListEntryType struct {
@@ -252,6 +255,26 @@ func (c *DashboardCommand) Run(args []string) int {
 				return 1
 			}
 
+			rendered, err := io.ReadAll(tmBuffer)
+			if err != nil {
+				fmt.Printf("Error rendering threatmodel: %s\n", err)
+				return 1
+			}
+
+			// When emitting HTML, convert the rendered Markdown to sanitized
+			// HTML. RenderMarkdown uses text/template, so threat-model fields
+			// (which may originate from untrusted .hcl files) are not escaped;
+			// writing that Markdown verbatim under a .html extension would let
+			// embedded markup execute as stored XSS when the dashboard is
+			// served or opened in a browser.
+			if c.flagDashboardHTML {
+				rendered, err = markdownToSafeHTML(rendered, tm.Name)
+				if err != nil {
+					fmt.Printf("Error rendering HTML: %s\n", err)
+					return 1
+				}
+			}
+
 			outfile := outfilePath(c.flagOutDir, tm.Name, file, fmt.Sprintf(".%s", outExt))
 
 			f, err := os.Create(outfile)
@@ -261,7 +284,7 @@ func (c *DashboardCommand) Run(args []string) int {
 			}
 			defer f.Close()
 
-			_, err = io.Copy(f, tmBuffer)
+			_, err = f.Write(rendered)
 			if err != nil {
 				fmt.Printf("Error writing to file: %s\n", err)
 				return 1
@@ -347,6 +370,49 @@ func (c *DashboardCommand) Run(args []string) int {
 func unixToTime(unixtime int64) string {
 	utime := time.Unix(unixtime, 0)
 	return utime.Format("2006-01-02")
+}
+
+// tmHTMLDocTemplate wraps sanitized threat-model HTML in a minimal document.
+// The body is pre-sanitized (bluemonday) before being marked template.HTML;
+// the title is a plain string and is context-escaped by html/template.
+var tmHTMLDocTemplate = template.Must(template.New("tmHTMLDoc").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ .Title }}</title>
+</head>
+<body>
+{{ .Body }}
+</body>
+</html>
+`))
+
+// markdownToSafeHTML converts rendered Markdown into a self-contained HTML
+// document. goldmark is used without the "unsafe" option (so raw HTML embedded
+// in the Markdown is not passed through), and the result is additionally run
+// through bluemonday's UGC policy. Together this ensures that HTML in untrusted
+// threat-model fields cannot execute as script when the dashboard is viewed.
+func markdownToSafeHTML(markdown []byte, title string) ([]byte, error) {
+	var htmlBuf bytes.Buffer
+	if err := goldmark.New().Convert(markdown, &htmlBuf); err != nil {
+		return nil, err
+	}
+
+	safe := bluemonday.UGCPolicy().SanitizeBytes(htmlBuf.Bytes())
+
+	var out bytes.Buffer
+	err := tmHTMLDocTemplate.Execute(&out, struct {
+		Title string
+		Body  template.HTML
+	}{
+		Title: title,
+		Body:  template.HTML(safe),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Bytes(), nil
 }
 
 // Synopsis returns the synopsis for the "threatcl dashboard" command

--- a/cmd/threatcl/dashboard_test.go
+++ b/cmd/threatcl/dashboard_test.go
@@ -681,3 +681,92 @@ func TestDashboardValidHtmlfile(t *testing.T) {
 	}
 
 }
+
+func TestDashboardHTMLSanitizesXSS(t *testing.T) {
+	srcDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Error creating tmp dir: %s", err)
+	}
+	defer os.RemoveAll(srcDir)
+
+	// Free-text threat-model fields can originate from untrusted .hcl files
+	// shared between users. When rendered to HTML they must not be able to
+	// execute script.
+	payload := "<script>alert(document.domain)</script><img src=x onerror=alert(1)>"
+	hcl := fmt.Sprintf(`
+spec_version = "0.4.0"
+
+threatmodel "xss model" {
+  description = "%s"
+  author = "test"
+
+  threat "a threat" {
+    description = "%s"
+    impacts = ["Confidentiality"]
+  }
+}
+`, payload, payload)
+
+	hclPath := filepath.Join(srcDir, "xss.hcl")
+	if err := os.WriteFile(hclPath, []byte(hcl), 0600); err != nil {
+		t.Fatalf("Error writing hcl: %s", err)
+	}
+
+	outDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Error creating out dir: %s", err)
+	}
+	defer os.RemoveAll(outDir)
+
+	cmd := testDashboardCommand(t)
+
+	var code int
+	out := capturer.CaptureStdout(func() {
+		code = cmd.Run([]string{
+			fmt.Sprintf("-outdir=%s", outDir),
+			"-overwrite",
+			"-dashboard-filename=index",
+			"-dashboard-html",
+			hclPath,
+		})
+	})
+
+	if code != 0 {
+		t.Fatalf("Code did not equal 0: %d\n%s", code, out)
+	}
+
+	// Inspect every generated per-model HTML file (everything except the
+	// dashboard index).
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("Error reading out dir: %s", err)
+	}
+
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".html" || e.Name() == "index.html" {
+			continue
+		}
+
+		body, err := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if err != nil {
+			t.Fatalf("Error reading %s: %s", e.Name(), err)
+		}
+		checked++
+
+		content := string(body)
+		if strings.Contains(content, "<script>") {
+			t.Errorf("per-model HTML %s contains an unescaped <script> tag:\n%s", e.Name(), content)
+		}
+		if strings.Contains(content, "onerror=") {
+			t.Errorf("per-model HTML %s contains an unsanitized onerror handler:\n%s", e.Name(), content)
+		}
+		if !strings.Contains(content, "<!DOCTYPE html>") {
+			t.Errorf("per-model HTML %s is not wrapped in an HTML document:\n%s", e.Name(), content)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no per-model HTML files were generated to check")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mark3labs/mcp-go v0.41.0
+	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mitchellh/cli v1.1.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/posener/complete v1.2.3
@@ -24,6 +25,7 @@ require (
 	github.com/tliron/commonlog v0.2.21
 	github.com/tliron/glsp v0.2.2
 	github.com/vektah/gqlparser/v2 v2.5.17
+	github.com/yuin/goldmark v1.7.13
 	github.com/zclconf/go-cty v1.18.1
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 )
@@ -126,7 +128,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.17 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
-	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
@@ -154,7 +155,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect


### PR DESCRIPTION
## Summary

`threatcl dashboard -dashboard-html` renders each threat model with `RenderMarkdown` — which uses `text/template` and therefore performs **no HTML escaping** — and writes the result to a `<name>.html` file. Threat-model free-text fields (description, author, threat/use-case text, …) can come from **untrusted `.hcl` files** shared between colleagues or pulled from repos, which is a normal threatcl workflow.

As a result, markup such as `<script>…</script>` or `<img src=x onerror=…>` placed in any of those fields would execute in the browser when the generated dashboard is served or opened — **stored XSS** affecting every viewer.

(The dashboard *index* was already safe — it's rendered with `html/template`. The per-model files were the unsanitized sink.)

## Changes

- On the `-dashboard-html` path, convert the rendered Markdown to a real HTML document:
  - **goldmark** performs Markdown→HTML **without** the unsafe option, so raw embedded HTML is not passed through;
  - the output is run through **bluemonday**'s UGC policy;
  - it's wrapped in a minimal HTML document whose `<title>` is context-escaped by `html/template`.
- As a side effect this makes `-dashboard-html` emit **actual HTML** (headings, bold, lists render) instead of raw Markdown under a `.html` extension.
- The default Markdown path (`-out-ext=md`) is unchanged.
- `goldmark` and `bluemonday` were already in the module graph (indirect, via glamour); they're now direct deps. No `go.sum` change.

## Testing

- New `TestDashboardHTMLSanitizesXSS`: renders a model whose fields contain `<script>` / `onerror` payloads and asserts the per-model `.html` output contains no `<script>` tag, no `onerror=` handler, and is wrapped in an HTML document. Fails without this fix.
- `go test ./cmd/threatcl/` — full package green.
- Manual render confirmed: `**bold**`→`<strong>`, headers→`<h1>/<h2>`, payloads stripped.

## Security review context

One of several findings from a security review of the repository. Independent, self-contained fix; sibling PRs address unrelated findings (server bind/CORS #183, and go-getter fetches from cloud-downloaded HCL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)