### PR TITLE
ci: flip harden-runner to egress block mode with per-job allowlists

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,10 +58,24 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Harden runner (egress audit)
+    - name: Harden runner (egress block)
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          *.actions.githubusercontent.com:443
+          api.github.com:443
+          codeload.github.com:443
+          dl.google.com:443
+          github.com:443
+          go.dev:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
+          storage.googleapis.com:443
+          sum.golang.org:443
+          uploads.github.com:443
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,10 +15,20 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden runner (egress audit)
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.deps.dev:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            codeload.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -21,10 +21,24 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden runner (egress audit)
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.github.com:443
+            codeload.github.com:443
+            dl.google.com:443
+            github.com:443
+            go.dev:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            vuln.go.dev:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Egress audit only for now: after a couple of clean audit baselines,
-      # flip to `egress-policy: block` with the observed `allowed-endpoints`.
-      - name: Harden runner (egress audit)
+      # Egress block: only the listed endpoints are reachable; anything else
+      # fails at connect time. List = the job's audit baseline (StepSecurity
+      # insights) plus GitHub/Go-infra cache-miss paths the same tools use.
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.github.com:443
+            auth.docker.io:443
+            codeload.github.com:443
+            dl.google.com:443
+            get.anchore.io:443
+            github.com:443
+            go.dev:443
+            objects.githubusercontent.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            toolbox-data.anchore.io:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -74,10 +94,25 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden runner (egress audit)
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.github.com:443
+            codeload.github.com:443
+            dl.google.com:443
+            get.anchore.io:443
+            github.com:443
+            go.dev:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            toolbox-data.anchore.io:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -141,12 +176,47 @@ jobs:
       artifact-metadata: write # storage record for attestations
     steps:
       # This job holds id-token + packages + contents write — the crown jewels.
-      # Egress audit only for now: after an audit baseline from a real release,
-      # flip to `egress-policy: block` with the observed `allowed-endpoints`.
-      - name: Harden runner (egress audit)
+      # Egress block. No tag has run under harden-runner yet, so this list is
+      # the validate/dev audit baseline (same GoReleaser build, incl. Docker)
+      # plus the publish-only endpoints: release upload (uploads.github.com),
+      # ghcr push (ghcr.io + pkg-containers), and Sigstore keyless signing
+      # (fulcio/rekor/tuf-repo-cdn). If a release fails on a blocked endpoint:
+      # the workflow at an existing tag is immutable, so fix this list on main
+      # and cut the next patch tag. Check what the failed run left behind
+      # first — GoReleaser pushes the ghcr images (incl. :latest) and then the
+      # GitHub Release BEFORE the attest steps run, so a failure during or
+      # after publish can leave a live release/image without provenance;
+      # delete those leftovers (or re-attest) before re-tagging. A failure
+      # before GoReleaser's publish phase leaves nothing published.
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.github.com:443
+            auth.docker.io:443
+            codeload.github.com:443
+            dl.google.com:443
+            fulcio.sigstore.dev:443
+            get.anchore.io:443
+            ghcr.io:443
+            github.com:443
+            go.dev:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            registry-1.docker.io:443
+            rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            toolbox-data.anchore.io:443
+            tuf-repo-cdn.sigstore.dev:443
+            uploads.github.com:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/threatcl-testvet.yml
+++ b/.github/workflows/threatcl-testvet.yml
@@ -9,10 +9,23 @@ jobs:
   testvet:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden runner (egress audit)
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.github.com:443
+            codeload.github.com:443
+            dl.google.com:443
+            github.com:443
+            go.dev:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,9 @@ jobs:
       contents: read
       security-events: write # upload SARIF findings to code scanning
     steps:
+      # Still audit (deliberately): this weekly workflow has never run, so
+      # there is no egress baseline to derive an allowlist from. Flip to
+      # `block` + `allowed-endpoints` after a couple of clean scheduled runs.
       - name: Harden runner (egress audit)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,10 +20,20 @@ jobs:
       contents: read
       security-events: write # upload SARIF findings to code scanning
     steps:
-      - name: Harden runner (egress audit)
+      - name: Harden runner (egress block)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.actions.githubusercontent.com:443
+            api.github.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docs/SLSA.md
+++ b/docs/SLSA.md
@@ -180,9 +180,21 @@ Do these **in order**, after the workflow change merges:
   branches and tags" with a tag rule for `v*` (defense-in-depth: the
   environment then refuses non-`v*` refs even if the workflow trigger were
   ever loosened).
-- [ ] After the next real release: pull the harden-runner audit baseline for
-  the `release` job and flip it to `egress-policy: block` +
-  `allowed-endpoints` (the standing Phase 5 follow-up).
+- [x] ~~After the next real release: pull the harden-runner audit baseline for
+  the `release` job and flip it~~ Done ahead of a release instead: every job
+  except `trivy` now runs `egress-policy: block` with an explicit
+  `allowed-endpoints` list derived from the StepSecurity audit baselines
+  (observed per-job egress across recent runs) plus the documented
+  publish-only endpoints for the `release` job (release upload, ghcr push,
+  Sigstore signing). `trivy` stays on audit until its weekly schedule has
+  produced a baseline. If a release ever fails on a blocked endpoint, fix the
+  list on `main` and cut the next patch tag — the workflow at an existing tag
+  is immutable. **Check what the failed run left behind first:** GoReleaser
+  pushes the ghcr images (incl. `:latest`) and then the GitHub Release
+  *before* the attest steps run, so a failure during or after the publish
+  phase can leave a live release/image without provenance attestations —
+  delete those leftovers (or re-attest) before re-tagging. Only a failure
+  before GoReleaser's publish phase leaves nothing published.
 
 The release flow becomes: push signed `v*` tag → `release` job pauses →
 approve in the UI → GoReleaser publishes (draft → immutable) → provenance
@@ -386,7 +398,7 @@ These underpin both tracks (a compromised Action can forge provenance or push to
 | Dependency review gate on PRs                        | ✅ (Phase 5) | `.github/workflows/dependency-review.yml` fails PRs that *introduce* deps with known vulns (`fail-on-severity: low`). |
 | zizmor (workflow static analysis)                    | ✅ (Phase 5) | `.github/workflows/zizmor.yml`, SARIF → code scanning. Baseline findings fixed: `persist-credentials: false` on every checkout; `cache: false` on `setup-go` in the artifact-building `release.yml` jobs (cache-poisoning). |
 | Trivy scan of the **published** image                | ✅ (Phase 5) | `.github/workflows/trivy.yml`, weekly + manual, scans `ghcr.io/threatcl/threatcl:latest` for newly disclosed base-layer (alpine) CVEs post-publication; SARIF → code scanning. Token-free replacement for the old Snyk container scan. |
-| harden-runner egress monitoring                      | 🔶 (Phase 5) | `step-security/harden-runner` on every job, `egress-policy: audit`. Follow-up: flip the `release` job (and then the rest) to `block` + `allowed-endpoints` once audit baselines exist. |
+| harden-runner egress enforcement                     | ✅ (Phase 5 audit → Phase 6 block) | `step-security/harden-runner` on every job. All jobs run `egress-policy: block` with explicit `allowed-endpoints` (from StepSecurity audit baselines + documented publish endpoints), except `trivy` which stays on audit until its weekly schedule produces a baseline. |
 | GoReleaser pinned to an exact version                | ✅ (Phase 5) | `goreleaser-action` previously floated `"~> v2"` — the binary is downloaded at run time, so the range was an unpinned build tool inside the most privileged job. Now `v2.16.0`, bumped deliberately. |
 | Base images digest-pinned                            | ✅ (Phase 5) | `Dockerfile` + `Dockerfile.goreleaser` pin `alpine`/`golang` bases by manifest-list digest; Dependabot's docker ecosystem updates digests alongside tags. |
 | SBOMs for released archives (SPDX, syft)             | ✅ (Phase 5) | `.goreleaser.yaml` `sboms:` emits one SBOM per archive; uploaded to releases and included in the `threatcl-dev` workflow artifact (Phase 6 retired the rolling `dev` pre-release), and covered by the release attestation step. The image already had an SBOM via `dockers_v2`. |
@@ -421,7 +433,8 @@ These underpin both tracks (a compromised Action can forge provenance or push to
 | 3     | README `gh attestation verify` docs (binaries + images-by-digest)      | Build L2 (consumer validation)   | ✅ |
 | 5     | Vuln scanning: `govulncheck` (push/PR + weekly) + PR dependency-review + weekly Trivy of the published image | Hygiene (vuln detection at source + post-publish) | ✅ |
 | 5     | zizmor workflow static analysis + baseline fixes (`persist-credentials: false` everywhere, no Go build cache in `release.yml`) | Hygiene (workflow control plane) | ✅ |
-| 5     | harden-runner on every job (`egress-policy: audit`)                     | Hygiene / Build isolation        | 🔶 audit; block pending baselines |
+| 5     | harden-runner on every job (`egress-policy: audit`)                     | Hygiene / Build isolation        | ✅ superseded by Phase 6 block |
+| 6     | harden-runner `egress-policy: block` + per-job `allowed-endpoints` on every job (trivy: audit until first baseline) | Hygiene / Build isolation (egress enforcement) | ✅ |
 | 5     | Exact GoReleaser version pin + digest-pinned base images                | Build (pinned toolchain + inputs)| ✅ |
 | 5     | SBOMs for released archives (syft, SPDX) — uploaded + attested          | Build (transparency)             | ✅ |
 | 5     | CodeQL `security-extended` suite (chosen over adding gosec)             | Hygiene (SAST depth)             | ✅ |


### PR DESCRIPTION
## What

Completes the standing #179/#187 follow-up: every job's harden-runner moves from `egress-policy: audit` to **`block`** with an explicit `allowed-endpoints` list — except [trivy.yml](.github/workflows/trivy.yml), which stays on audit deliberately (its weekly schedule has never fired, so there is no baseline; a comment says when to flip it).

With block mode, a compromised action or dependency in any of these jobs can no longer exfiltrate to arbitrary hosts — outbound connections off-list fail at connect time.

## Where the lists come from

- **Observed baselines**: per-job egress harvested from StepSecurity insights across recent successful runs (up to 4 per workflow) — this is the audit data #179 set out to collect.
- **GitHub/Go infra cache-miss paths**: codeload + objects/release-assets CDNs, `go.dev`/`dl.google.com` toolchain fallback — endpoints the same tools hit when runner caches miss, deliberately included to avoid flakes.
- **Release job** (never run under harden-runner — no tag since #179): the `validate`/`dev` baselines (same GoReleaser build, including the Docker/QEMU pulls) plus the publish-only endpoints: `uploads.github.com` (release assets), `ghcr.io` + `pkg-containers.githubusercontent.com` (image push), `fulcio`/`rekor`/`tuf-repo-cdn.sigstore.dev` (keyless signing). Same shape as [DataDog/stratus-red-team's block-mode GoReleaser release job](https://github.com/DataDog/stratus-red-team/blob/main/.github/workflows/release.yml).

## Validation

- **This PR's own CI runs every pull_request-triggered job under block mode** — including the full GoReleaser cross-platform + Docker dry-run (`validate`). A green check here is a live proof of each list.
- An adversarial review pass verified against the pinned harden-runner agent source: folded-scalar endpoint format matches the agent's parser, wildcards are supported, GitHub Actions control-plane endpoints (results-receiver, blob hosts, `*.actions.githubusercontent.com`) are implicitly allowed, and blocked hosts sinkhole at DNS. It found **no missing endpoints** in any list.
- actionlint + zizmor clean.

## Release-failure recovery (documented in the workflow + docs/SLSA.md)

The workflow at an existing tag is immutable, so a blocked endpoint in a real release means: fix the list on `main`, **check what the failed run left behind** (GoReleaser pushes the ghcr images and the Release *before* the attest steps — a late failure can leave a published-but-unattested release/`:latest` image to clean up), then cut the next patch tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)